### PR TITLE
[Switch] Add transitions for Switch thumb and track colors

### DIFF
--- a/src/components/forms/controls/Switch/Switch.module.scss
+++ b/src/components/forms/controls/Switch/Switch.module.scss
@@ -1,10 +1,10 @@
 
 @use '../../../../styling/defs.scss' as bk;
 
-/* Note: `light-dark()` does not seem to be animatable in Chrome 125, even with `@property` */
-// @property --bk-switch-track-color { syntax: '<color>'; inherits: true; initial-value: bk.$color-grey-600; }
-// @property --bk-switch-thumb-color { syntax: '<color>'; inherits: true; initial-value: bk.$color-grey-400; }
+/* Give these custom properties types to allow them to be animated */
 @property --bk-switch-pos { syntax: '<length-percentage>'; inherits: true; initial-value: 50%; }
+@property --bk-switch-track-color { syntax: '<color>'; inherits: true; initial-value: transparent; }
+@property --bk-switch-thumb-color { syntax: '<color>'; inherits: true; initial-value: transparent; }
 
 @layer baklava.components {
   .bk-switch {


### PR DESCRIPTION
When I tried to get color transitions to work back in Chrome v125, it seemed to not work with light-dark(). I tried it again now, and the colors correctly transition. Firefox and Safari also work correctly. So either this got fixed in the meantime, or maybe I did something wrong. Maybe the issue was `initial-value` should have been a plain color expression rather than `light-dark()`, since according to the spec `initial-value` must be "computationally independent", and `light-dark()` is not.

In any case, this PR fixes it so that now Switch has color transitions.