### PR TITLE
Upgrade to React v19 stable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "effect": "^3.10.19",
         "message-tag": "^0.10.0",
         "optics-ts": "^2.4.1",
-        "react": "^19.0.0-rc.1",
-        "react-dom": "^19.0.0-rc.1",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "react-error-boundary": "^4.1.2",
         "react-hook-form": "^7.53.2",
         "react-toastify": "^10.0.6"
@@ -26,19 +26,19 @@
         "@chromatic-com/storybook": "^3.2.2",
         "@percy/cli": "^1.30.3",
         "@percy/storybook": "^6.0.3",
-        "@storybook/addon-a11y": "^8.4.6",
+        "@storybook/addon-a11y": "^8.4.7",
         "@storybook/addon-designs": "^8.0.4",
-        "@storybook/addon-essentials": "^8.4.6",
-        "@storybook/addon-interactions": "^8.4.6",
-        "@storybook/addon-links": "^8.4.6",
-        "@storybook/addon-storysource": "^8.4.6",
-        "@storybook/blocks": "^8.4.6",
-        "@storybook/react": "^8.4.6",
-        "@storybook/react-vite": "^8.4.6",
-        "@storybook/test": "^8.4.6",
+        "@storybook/addon-essentials": "^8.4.7",
+        "@storybook/addon-interactions": "^8.4.7",
+        "@storybook/addon-links": "^8.4.7",
+        "@storybook/addon-storysource": "^8.4.7",
+        "@storybook/blocks": "^8.4.7",
+        "@storybook/react": "^8.4.7",
+        "@storybook/react-vite": "^8.4.7",
+        "@storybook/test": "^8.4.7",
         "@types/node": "^22.10.1",
-        "@types/react": "npm:types-react@rc",
-        "@types/react-dom": "npm:types-react-dom@rc",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.4",
         "@vitest/ui": "^2.1.6",
         "glob": "^11.0.0",
@@ -46,7 +46,7 @@
         "plop": "^4.0.1",
         "postcss-color-contrast": "^1.1.0",
         "sass": "^1.81.0",
-        "storybook": "^8.4.6",
+        "storybook": "^8.4.7",
         "storybook-dark-mode": "^4.0.2",
         "stylelint": "^16.11.0",
         "stylelint-config-standard-scss": "^13.1.0",
@@ -61,8 +61,8 @@
         "vitest": "^2.1.6"
       },
       "peerDependencies": {
-        "react": ">= 19.0.0-rc.1",
-        "react-dom": ">= 19.0.0-rc.1"
+        "react": ">= 19.0.0",
+        "react-dom": ">= 19.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -692,6 +692,34 @@
         "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
       }
     },
+    "node_modules/@chromatic-com/storybook/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@chromatic-com/storybook/node_modules/react-confetti": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-confetti/-/react-confetti-6.1.0.tgz",
+      "integrity": "sha512-7Ypx4vz0+g8ECVxr88W9zhcQpbeujJAVqL14ZnXJ3I23mOI9/oBVTQ3dkJhUmB0D6XOtCZEM6N0Gm9PMngkORw==",
+      "dev": true,
+      "dependencies": {
+        "tween-functions": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10.18"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.1 || ^18.0.0"
+      }
+    },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.4.tgz",
@@ -1180,23 +1208,8 @@
       "resolved": "https://registry.npmjs.org/@figspec/components/-/components-1.0.3.tgz",
       "integrity": "sha512-fBwHzJ4ouuOUJEi+yBZIrOy+0/fAjB3AeTcIHTT1PRxLz8P63xwC7R0EsIJXhScIcc+PljGmqbbVJCjLsnaGYA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "lit": "^2.1.3"
-      }
-    },
-    "node_modules/@figspec/react": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@figspec/react/-/react-1.0.3.tgz",
-      "integrity": "sha512-r683qOko+5CbT48Ox280fMx2MNAtaFPgCNJvldOqN3YtmAzlcTT+YSxd3OahA+kjXGGrnzDbUgeTOX1cPLII+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@figspec/components": "^1.0.1",
-        "@lit-labs/react": "^1.0.2"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -1380,24 +1393,38 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-1.2.1.tgz",
       "integrity": "sha512-DiZdJYFU0tBbdQkfwwRSwYyI/mcWkg3sWesKRsHUd4G+NekTmmeq9fzsurvcKTNVa0comNljwtg4Hvi1ds3V+A==",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "dev": true
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.1.tgz",
       "integrity": "sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "dev": true
     },
     "node_modules/@lit/reactive-element": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
       "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
+    "node_modules/@mdx-js/react": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.0.tgz",
+      "integrity": "sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdx": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16",
+        "react": ">=16"
       }
     },
     "node_modules/@microsoft/api-extractor": {
@@ -2566,12 +2593,12 @@
       "license": "MIT"
     },
     "node_modules/@storybook/addon-a11y": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-8.4.6.tgz",
-      "integrity": "sha512-Z6x/yfStplSROgmBTtiJ8LJgTqPgzW3Q7KXi+l+KoZ0pht6Nz9cYfcyygLCaftBk1ZaL7SDDIrjCP0H1NwfYiQ==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-8.4.7.tgz",
+      "integrity": "sha512-GpUvXp6n25U1ZSv+hmDC+05BEqxWdlWjQTb/GaboRXZQeMBlze6zckpVb66spjmmtQAIISo0eZxX1+mGcVR7lA==",
       "dev": true,
       "dependencies": {
-        "@storybook/addon-highlight": "8.4.6",
+        "@storybook/addon-highlight": "8.4.7",
         "axe-core": "^4.2.0"
       },
       "funding": {
@@ -2579,13 +2606,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.4.6"
+        "storybook": "^8.4.7"
       }
     },
     "node_modules/@storybook/addon-actions": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-8.4.6.tgz",
-      "integrity": "sha512-vbplwjMj7UXbdzoFhQkqFHLQAPJX8OVGTM9Q+yjuWDHViaKKUlgRWp0jclT7aIDNJQU2a6wJbTimHgJeF16Vhg==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-8.4.7.tgz",
+      "integrity": "sha512-mjtD5JxcPuW74T6h7nqMxWTvDneFtokg88p6kQ5OnC1M259iAXb//yiSZgu/quunMHPCXSiqn4FNOSgASTSbsA==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
@@ -2599,13 +2626,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.4.6"
+        "storybook": "^8.4.7"
       }
     },
     "node_modules/@storybook/addon-backgrounds": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-8.4.6.tgz",
-      "integrity": "sha512-RSjJ3iElxlQXebZrz1s5LeoLpAXr9LAGifX7w0abMzN5sg6QSwNeUHko2eT3V57M3k1Fa/5Eelso/QBQifFEog==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-8.4.7.tgz",
+      "integrity": "sha512-I4/aErqtFiazcoWyKafOAm3bLpxTj6eQuH/woSbk1Yx+EzN+Dbrgx1Updy8//bsNtKkcrXETITreqHC+a57DHQ==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
@@ -2617,13 +2644,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.4.6"
+        "storybook": "^8.4.7"
       }
     },
     "node_modules/@storybook/addon-controls": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-8.4.6.tgz",
-      "integrity": "sha512-70pEGWh0C2g8s0DYsISElOzsMbQS6p/K9iU5EqfotDF+hvEqstjsV/bTbR5f3OK4vR/7Gxamk7j8RVd14Nql6A==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-8.4.7.tgz",
+      "integrity": "sha512-377uo5IsJgXLnQLJixa47+11V+7Wn9KcDEw+96aGCBCfLbWNH8S08tJHHnSu+jXg9zoqCAC23MetntVp6LetHA==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
@@ -2635,7 +2662,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.4.6"
+        "storybook": "^8.4.7"
       }
     },
     "node_modules/@storybook/addon-designs": {
@@ -2643,7 +2670,6 @@
       "resolved": "https://registry.npmjs.org/@storybook/addon-designs/-/addon-designs-8.0.4.tgz",
       "integrity": "sha512-BrEWks1BRnZis2e8OoE1LhFS+x2d094Tzpbb3jQBve2IfDv/X006RSuy1WyplNxskdYdBESCH45MlRn4lhP5ew==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@figspec/react": "^1.0.0"
       },
@@ -2672,16 +2698,29 @@
         }
       }
     },
+    "node_modules/@storybook/addon-designs/node_modules/@figspec/react": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@figspec/react/-/react-1.0.3.tgz",
+      "integrity": "sha512-r683qOko+5CbT48Ox280fMx2MNAtaFPgCNJvldOqN3YtmAzlcTT+YSxd3OahA+kjXGGrnzDbUgeTOX1cPLII+g==",
+      "dev": true,
+      "dependencies": {
+        "@figspec/components": "^1.0.1",
+        "@lit-labs/react": "^1.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@storybook/addon-docs": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-8.4.6.tgz",
-      "integrity": "sha512-olxz61W7PW/EsXrKhLrYbI3rn9GMBhY3KIOF/6tumbRkh0Siu/qe4EAImaV9NNwiC1R7+De/1OIVMY6o0EIZVw==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-8.4.7.tgz",
+      "integrity": "sha512-NwWaiTDT5puCBSUOVuf6ME7Zsbwz7Y79WF5tMZBx/sLQ60vpmJVQsap6NSjvK1Ravhc21EsIXqemAcBjAWu80w==",
       "dev": true,
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/blocks": "8.4.6",
-        "@storybook/csf-plugin": "8.4.6",
-        "@storybook/react-dom-shim": "8.4.6",
+        "@storybook/blocks": "8.4.7",
+        "@storybook/csf-plugin": "8.4.7",
+        "@storybook/react-dom-shim": "8.4.7",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "ts-dedent": "^2.0.0"
@@ -2691,24 +2730,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.4.6"
-      }
-    },
-    "node_modules/@storybook/addon-docs/node_modules/@mdx-js/react": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.0.tgz",
-      "integrity": "sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/mdx": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16",
-        "react": ">=16"
+        "storybook": "^8.4.7"
       }
     },
     "node_modules/@storybook/addon-docs/node_modules/react": {
@@ -2746,20 +2768,20 @@
       }
     },
     "node_modules/@storybook/addon-essentials": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-8.4.6.tgz",
-      "integrity": "sha512-TbFqyvWFUKw8LBpVcZuGQydzVB/3kSuHxDHi+Wj3Qas3cxBl7+w4/HjwomT2D2Tni1dZ1uPDOsAtNLmwp1POsg==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-8.4.7.tgz",
+      "integrity": "sha512-+BtZHCBrYtQKILtejKxh0CDRGIgTl9PumfBOKRaihYb4FX1IjSAxoV/oo/IfEjlkF5f87vouShWsRa8EUauFDw==",
       "dev": true,
       "dependencies": {
-        "@storybook/addon-actions": "8.4.6",
-        "@storybook/addon-backgrounds": "8.4.6",
-        "@storybook/addon-controls": "8.4.6",
-        "@storybook/addon-docs": "8.4.6",
-        "@storybook/addon-highlight": "8.4.6",
-        "@storybook/addon-measure": "8.4.6",
-        "@storybook/addon-outline": "8.4.6",
-        "@storybook/addon-toolbars": "8.4.6",
-        "@storybook/addon-viewport": "8.4.6",
+        "@storybook/addon-actions": "8.4.7",
+        "@storybook/addon-backgrounds": "8.4.7",
+        "@storybook/addon-controls": "8.4.7",
+        "@storybook/addon-docs": "8.4.7",
+        "@storybook/addon-highlight": "8.4.7",
+        "@storybook/addon-measure": "8.4.7",
+        "@storybook/addon-outline": "8.4.7",
+        "@storybook/addon-toolbars": "8.4.7",
+        "@storybook/addon-viewport": "8.4.7",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -2767,13 +2789,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.4.6"
+        "storybook": "^8.4.7"
       }
     },
     "node_modules/@storybook/addon-highlight": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-8.4.6.tgz",
-      "integrity": "sha512-m8wedbqDMbwkP99dNHkHAiAUkx5E7FEEEyLPX1zfkhZWOGtTkavXHH235SGp50zD75LQ6eC/BvgegrzxSQa9Wg==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-8.4.7.tgz",
+      "integrity": "sha512-whQIDBd3PfVwcUCrRXvCUHWClXe9mQ7XkTPCdPo4B/tZ6Z9c6zD8JUHT76ddyHivixFLowMnA8PxMU6kCMAiNw==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0"
@@ -2783,18 +2805,18 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.4.6"
+        "storybook": "^8.4.7"
       }
     },
     "node_modules/@storybook/addon-interactions": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-interactions/-/addon-interactions-8.4.6.tgz",
-      "integrity": "sha512-sR2oUSYIGUoAdrHT+fM1zgykhad98bsJ11c79r7HfBMXEPWc1yRcjIMmz8Xz06FMROMfebqduYDf60V++/I0Jw==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-interactions/-/addon-interactions-8.4.7.tgz",
+      "integrity": "sha512-fnufT3ym8ht3HHUIRVXAH47iOJW/QOb0VSM+j269gDuvyDcY03D1civCu1v+eZLGaXPKJ8vtjr0L8zKQ/4P0JQ==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/instrumenter": "8.4.6",
-        "@storybook/test": "8.4.6",
+        "@storybook/instrumenter": "8.4.7",
+        "@storybook/test": "8.4.7",
         "polished": "^4.2.2",
         "ts-dedent": "^2.2.0"
       },
@@ -2803,13 +2825,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.4.6"
+        "storybook": "^8.4.7"
       }
     },
     "node_modules/@storybook/addon-links": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-8.4.6.tgz",
-      "integrity": "sha512-1KoG9ytEWWwdF/dheu1O0dayQTMsHw++Qk8afqw7bwW1Cxz5LuAJH5ZscFWMiE5f4Xq1NgaJdeAUaIavyoOcdg==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-8.4.7.tgz",
+      "integrity": "sha512-L/1h4dMeMKF+MM0DanN24v5p3faNYbbtOApMgg7SlcBT/tgo3+cAjkgmNpYA8XtKnDezm+T2mTDhB8mmIRZpIQ==",
       "dev": true,
       "dependencies": {
         "@storybook/csf": "^0.1.11",
@@ -2822,7 +2844,7 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^8.4.6"
+        "storybook": "^8.4.7"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -2831,9 +2853,9 @@
       }
     },
     "node_modules/@storybook/addon-measure": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-8.4.6.tgz",
-      "integrity": "sha512-N2IRpr39g5KpexCAS1vIHJT+phc9Yilwm3PULds2rQ66VMTbkxobXJDdt0NS05g5n9/eDniroNQwdCeLg4tkpw==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-8.4.7.tgz",
+      "integrity": "sha512-QfvqYWDSI5F68mKvafEmZic3SMiK7zZM8VA0kTXx55hF/+vx61Mm0HccApUT96xCXIgmwQwDvn9gS4TkX81Dmw==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
@@ -2844,13 +2866,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.4.6"
+        "storybook": "^8.4.7"
       }
     },
     "node_modules/@storybook/addon-outline": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-outline/-/addon-outline-8.4.6.tgz",
-      "integrity": "sha512-EhcWx8OpK85HxQulLWzpWUHEwQpDYuAiKzsFj9ivAbfeljkIWNTG04mierfaH1xX016uL9RtLJL/zwBS5ChnFg==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-outline/-/addon-outline-8.4.7.tgz",
+      "integrity": "sha512-6LYRqUZxSodmAIl8icr585Oi8pmzbZ90aloZJIpve+dBAzo7ydYrSQxxoQEVltXbKf3VeVcrs64ouAYqjisMYA==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
@@ -2861,16 +2883,16 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.4.6"
+        "storybook": "^8.4.7"
       }
     },
     "node_modules/@storybook/addon-storysource": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-storysource/-/addon-storysource-8.4.6.tgz",
-      "integrity": "sha512-JZZnii8FYVEoWoLYJa4AKeik25kFzvyRvKT8vTdqcjx7S2bgxup27vub9VVEmnSq1Q3Q3WyN/7rX8AyNxIr0ew==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-storysource/-/addon-storysource-8.4.7.tgz",
+      "integrity": "sha512-ckMSiVf+8V3IVN3lTdzCdToXVoGhZ57pwMv0OpkdVIEn6sqHFHwHrOYiXpF3SXTicwayjylcL1JXTGoBFFDVOQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/source-loader": "8.4.6",
+        "@storybook/source-loader": "8.4.7",
         "estraverse": "^5.2.0",
         "tiny-invariant": "^1.3.1"
       },
@@ -2879,26 +2901,26 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.4.6"
+        "storybook": "^8.4.7"
       }
     },
     "node_modules/@storybook/addon-toolbars": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-8.4.6.tgz",
-      "integrity": "sha512-+Xao/uGa8FnYsyUiREUkYXWNysm3Aba8tL/Bwd+HufHtdiKJGa9lrXaC7VLCqBUaEjwqM3aaPwqEWIROsthmPQ==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-8.4.7.tgz",
+      "integrity": "sha512-OSfdv5UZs+NdGB+nZmbafGUWimiweJ/56gShlw8Neo/4jOJl1R3rnRqqY7MYx8E4GwoX+i3GF5C3iWFNQqlDcw==",
       "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.4.6"
+        "storybook": "^8.4.7"
       }
     },
     "node_modules/@storybook/addon-viewport": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-8.4.6.tgz",
-      "integrity": "sha512-BuQll5YzOCpMS7p5Rsw9wcmi8hTnEKyg6+qAbkZNfiZ2JhXCa1GFUqX725fF1whpYVQULtkQxU8r+vahoRn7Yg==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-8.4.7.tgz",
+      "integrity": "sha512-hvczh/jjuXXcOogih09a663sRDDSATXwbE866al1DXgbDFraYD/LxX/QDb38W9hdjU9+Qhx8VFIcNWoMQns5HQ==",
       "dev": true,
       "dependencies": {
         "memoizerific": "^1.11.3"
@@ -2908,13 +2930,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.4.6"
+        "storybook": "^8.4.7"
       }
     },
     "node_modules/@storybook/blocks": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-8.4.6.tgz",
-      "integrity": "sha512-Gzbx8hM7ZQIHlQELcFIMbY1v+r1Po4mlinq0QVPtKS4lBcW4eZIsesbxOaL+uFNrxb583TLFzXo0DbRPzS46sg==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-8.4.7.tgz",
+      "integrity": "sha512-+QH7+JwXXXIyP3fRCxz/7E2VZepAanXJM7G8nbR3wWsqWgrRp4Wra6MvybxAYCxU7aNfJX5c+RW84SNikFpcIA==",
       "dev": true,
       "dependencies": {
         "@storybook/csf": "^0.1.11",
@@ -2928,7 +2950,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^8.4.6"
+        "storybook": "^8.4.7"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -2939,13 +2961,26 @@
         }
       }
     },
+    "node_modules/@storybook/blocks/node_modules/@storybook/icons": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-1.2.12.tgz",
+      "integrity": "sha512-UxgyK5W3/UV4VrI3dl6ajGfHM4aOqMAkFLWe2KibeQudLf6NJpDrDMSHwZj+3iKC4jFU7dkKbbtH2h/al4sW3Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@storybook/builder-vite": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-8.4.6.tgz",
-      "integrity": "sha512-PyJsaEPyuRFFEplpNUi+nbuJd7d1DC2dAZjpsaHTXyqg5iPIbkIgsbCJLUDeIXnUDqM/utjmMpN0sQKJuhIc6w==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-8.4.7.tgz",
+      "integrity": "sha512-LovyXG5VM0w7CovI/k56ZZyWCveQFVDl0m7WwetpmMh2mmFJ+uPQ35BBsgTvTfc8RHi+9Q3F58qP1MQSByXi9g==",
       "dev": true,
       "dependencies": {
-        "@storybook/csf-plugin": "8.4.6",
+        "@storybook/csf-plugin": "8.4.7",
         "browser-assert": "^1.2.1",
         "ts-dedent": "^2.0.0"
       },
@@ -2954,14 +2989,14 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.4.6",
+        "storybook": "^8.4.7",
         "vite": "^4.0.0 || ^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/@storybook/components": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-8.4.6.tgz",
-      "integrity": "sha512-9tKSJJCyFT5RZMRGyozTBJkr9C9Yfk1nuOE9XbDEE1Z+3/IypKR9+iwc5mfNBStDNY+rxtYWNLKBb5GPR2yhzA==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-8.4.7.tgz",
+      "integrity": "sha512-uyJIcoyeMWKAvjrG9tJBUCKxr2WZk+PomgrgrUwejkIfXMO76i6jw9BwLa0NZjYdlthDv30r9FfbYZyeNPmF0g==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -2972,9 +3007,9 @@
       }
     },
     "node_modules/@storybook/core": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.4.6.tgz",
-      "integrity": "sha512-WeojVtHy0/t50tzw/15S+DLzKsj8BN9yWdo3vJMvm+nflLFvfq1XvD9WGOWeaFp8E/o3AP+4HprXG0r42KEJtA==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.4.7.tgz",
+      "integrity": "sha512-7Z8Z0A+1YnhrrSXoKKwFFI4gnsLbWzr8fnDCU6+6HlDukFYh8GHRcZ9zKfqmy6U3hw2h8H5DrHsxWfyaYUUOoA==",
       "dev": true,
       "dependencies": {
         "@storybook/csf": "^0.1.11",
@@ -3039,9 +3074,9 @@
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.4.6.tgz",
-      "integrity": "sha512-JDIT0czC4yMgKGNf39KTZr3zm5MusAZdn6LBrTfvWb7CrTCR4iVHa4lp2yb7EJk41vHsBec0QUYDDuiFH/vV0g==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.4.7.tgz",
+      "integrity": "sha512-Fgogplu4HImgC+AYDcdGm1rmL6OR1rVdNX1Be9C/NEXwOCpbbBwi0BxTf/2ZxHRk9fCeaPEcOdP5S8QHfltc1g==",
       "dev": true,
       "dependencies": {
         "unplugin": "^1.3.1"
@@ -3051,7 +3086,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.4.6"
+        "storybook": "^8.4.7"
       }
     },
     "node_modules/@storybook/global": {
@@ -3061,24 +3096,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@storybook/icons": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-1.2.12.tgz",
-      "integrity": "sha512-UxgyK5W3/UV4VrI3dl6ajGfHM4aOqMAkFLWe2KibeQudLf6NJpDrDMSHwZj+3iKC4jFU7dkKbbtH2h/al4sW3Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/@storybook/instrumenter": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/instrumenter/-/instrumenter-8.4.6.tgz",
-      "integrity": "sha512-snXjlgbp065A6KoK9zkjBYEIMCSlN5JefPKzt1FC0rbcbtahhD+iPpqISKhDSczwgOku/JVhVUDp/vU7AIf4mg==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/instrumenter/-/instrumenter-8.4.7.tgz",
+      "integrity": "sha512-k6NSD3jaRCCHAFtqXZ7tw8jAzD/yTEWXGya+REgZqq5RCkmJ+9S4Ytp/6OhQMPtPFX23gAuJJzTQVLcCr+gjRg==",
       "dev": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
@@ -3089,13 +3110,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.4.6"
+        "storybook": "^8.4.7"
       }
     },
     "node_modules/@storybook/manager-api": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.4.6.tgz",
-      "integrity": "sha512-TsXlQ5m5rTl2KNT9icPFyy822AqXrx1QplZBt/L7cFn7SpqQKDeSta21FH7MG0piAvzOweXebVSqKngJ6cCWWQ==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.4.7.tgz",
+      "integrity": "sha512-ELqemTviCxAsZ5tqUz39sDmQkvhVAvAgiplYy9Uf15kO0SP2+HKsCMzlrm2ue2FfkUNyqbDayCPPCB0Cdn/mpQ==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -3106,9 +3127,9 @@
       }
     },
     "node_modules/@storybook/preview-api": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.4.6.tgz",
-      "integrity": "sha512-LbD+lR1FGvWaJBXteVx5xdgs1x1D7tyidBg2CsW2ex+cP0iJ176JgjPfutZxlWOfQnhfRYNnJ3WKoCIfxFOTKA==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.4.7.tgz",
+      "integrity": "sha512-0QVQwHw+OyZGHAJEXo6Knx+6/4er7n2rTDE5RYJ9F2E2Lg42E19pfdLlq2Jhoods2Xrclo3wj6GWR//Ahi39Eg==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -3119,17 +3140,17 @@
       }
     },
     "node_modules/@storybook/react": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-8.4.6.tgz",
-      "integrity": "sha512-QAT23beoYNLhFGAXPimtuMErvpcI7eZbZ4AlLqW1fhiTZrRYw06cjC1bs9H3tODMcHH9LS5p3Wz9b29jtV2XGw==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-8.4.7.tgz",
+      "integrity": "sha512-nQ0/7i2DkaCb7dy0NaT95llRVNYWQiPIVuhNfjr1mVhEP7XD090p0g7eqUmsx8vfdHh2BzWEo6CoBFRd3+EXxw==",
       "dev": true,
       "dependencies": {
-        "@storybook/components": "8.4.6",
+        "@storybook/components": "8.4.7",
         "@storybook/global": "^5.0.0",
-        "@storybook/manager-api": "8.4.6",
-        "@storybook/preview-api": "8.4.6",
-        "@storybook/react-dom-shim": "8.4.6",
-        "@storybook/theming": "8.4.6"
+        "@storybook/manager-api": "8.4.7",
+        "@storybook/preview-api": "8.4.7",
+        "@storybook/react-dom-shim": "8.4.7",
+        "@storybook/theming": "8.4.7"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -3139,10 +3160,10 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "@storybook/test": "8.4.6",
+        "@storybook/test": "8.4.7",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^8.4.6",
+        "storybook": "^8.4.7",
         "typescript": ">= 4.2.x"
       },
       "peerDependenciesMeta": {
@@ -3155,9 +3176,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-8.4.6.tgz",
-      "integrity": "sha512-f7RM8GO++fqMxbjNdEzeGS1P821jXuwRnAraejk5hyjB5SqetauFxMwoFYEYfJXPaLX2qIubnIJ78hdJ/IBaEA==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-8.4.7.tgz",
+      "integrity": "sha512-6bkG2jvKTmWrmVzCgwpTxwIugd7Lu+2btsLAqhQSzDyIj2/uhMNp8xIMr/NBDtLgq3nomt9gefNa9xxLwk/OMg==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -3166,19 +3187,19 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^8.4.6"
+        "storybook": "^8.4.7"
       }
     },
     "node_modules/@storybook/react-vite": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-8.4.6.tgz",
-      "integrity": "sha512-bVoYj3uJRz0SknK2qN3vBVSoEXsvyARQLuHjP9eX0lWBd9XSxZinmVbexPdD0OeJYcJIdmbli2/Gw7/hu5CjFA==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-8.4.7.tgz",
+      "integrity": "sha512-iiY9iLdMXhDnilCEVxU6vQsN72pW3miaf0WSenOZRyZv3HdbpgOxI0qapOS0KCyRUnX9vTlmrSPTMchY4cAeOg==",
       "dev": true,
       "dependencies": {
         "@joshwooding/vite-plugin-react-docgen-typescript": "0.4.2",
         "@rollup/pluginutils": "^5.0.2",
-        "@storybook/builder-vite": "8.4.6",
-        "@storybook/react": "8.4.6",
+        "@storybook/builder-vite": "8.4.7",
+        "@storybook/react": "8.4.7",
         "find-up": "^5.0.0",
         "magic-string": "^0.30.0",
         "react-docgen": "^7.0.0",
@@ -3195,14 +3216,14 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^8.4.6",
+        "storybook": "^8.4.7",
         "vite": "^4.0.0 || ^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/@storybook/source-loader": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/source-loader/-/source-loader-8.4.6.tgz",
-      "integrity": "sha512-Z9pUuoy7Wg8qHuZ31XRE+HYTJfub9rcPnWAC7PDQ6vkJQX2HjIz+CIr0+77zpv/kWPfAZ0CHmlopa0lVmj7DIA==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/source-loader/-/source-loader-8.4.7.tgz",
+      "integrity": "sha512-DrsYGGfNbbqlMzkhbLoNyNqrPa4QIkZ6O7FJ8Z/8jWb0cerQH2N6JW6k12ZnXgs8dO2Z33+iSEDIV8odh0E0PA==",
       "dev": true,
       "dependencies": {
         "@storybook/csf": "^0.1.11",
@@ -3215,18 +3236,18 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.4.6"
+        "storybook": "^8.4.7"
       }
     },
     "node_modules/@storybook/test": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/test/-/test-8.4.6.tgz",
-      "integrity": "sha512-MeU1g65YgU66M2NtmEIL9gVeHk+en0k9Hp0wfxEO7NT/WLfaOD5RXLRDJVhbAlrH/6tLeWKIPNh/D26y27vO/g==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/test/-/test-8.4.7.tgz",
+      "integrity": "sha512-AhvJsu5zl3uG40itSQVuSy5WByp3UVhS6xAnme4FWRwgSxhvZjATJ3AZkkHWOYjnnk+P2/sbz/XuPli1FVCWoQ==",
       "dev": true,
       "dependencies": {
         "@storybook/csf": "^0.1.11",
         "@storybook/global": "^5.0.0",
-        "@storybook/instrumenter": "8.4.6",
+        "@storybook/instrumenter": "8.4.7",
         "@testing-library/dom": "10.4.0",
         "@testing-library/jest-dom": "6.5.0",
         "@testing-library/user-event": "14.5.2",
@@ -3238,13 +3259,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.4.6"
+        "storybook": "^8.4.7"
       }
     },
     "node_modules/@storybook/theming": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.4.6.tgz",
-      "integrity": "sha512-q7vDPN/mgj7cXIVQ9R1/V75hrzNgKkm2G0LjMo57//9/djQ+7LxvBsR1iScbFIRSEqppvMiBFzkts+2uXidySA==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.4.7.tgz",
+      "integrity": "sha512-99rgLEjf7iwfSEmdqlHkSG3AyLcK0sfExcr0jnc6rLiAkBhzuIsvcHjjUwkR210SOCgXqBPW0ZA6uhnuyppHLw==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -3472,20 +3493,18 @@
       }
     },
     "node_modules/@types/react": {
-      "name": "types-react",
-      "version": "19.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/types-react/-/types-react-19.0.0-rc.1.tgz",
-      "integrity": "sha512-RshndUfqTW6K3STLPis8BtAYCGOkMbtvYsi90gmVNDZBXUyUc5juf2PE9LfS/JmOlUIRO8cWTS/1MTnmhjDqyQ==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-MY3oPudxvMYyesqs/kW1Bh8y9VqSmf+tzqw3ae8a9DZW68pUe3zAdHeI1jc6iAysuRdACnVknHP8AhwD4/dxtg==",
       "dev": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "name": "types-react-dom",
-      "version": "19.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/types-react-dom/-/types-react-dom-19.0.0-rc.1.tgz",
-      "integrity": "sha512-VSLZJl8VXCD0fAWp7DUTFUDCcZ8DVXOQmjhJMD03odgeFmu14ZQJHCXeETm3BEAhJqfgJaFkLnGkQv88sRx0fQ==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.0.tgz",
+      "integrity": "sha512-1KfiQKsH1o00p9m5ag12axHQSb3FOU9H20UTrujVSkNhuCrRHiQWFqgEnTNK5ZNfnzZv8UWrnXVqCmCF9fgY3w==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
@@ -3522,8 +3541,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
@@ -5707,9 +5725,9 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.27.0.tgz",
-      "integrity": "sha512-ETSFA+ZJArcuSCpzD2TjAy6UHpx4E4uqFsoDg9F/nTLogrLmVVZQ+zNxco5h7cWnA1nNak07IXsLcaSMih+ZPQ==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.29.0.tgz",
+      "integrity": "sha512-GjTll+E6APcfAQA09D89HdT8Qn2Yb+TeDSDBTMcxAo+V+w1amAtCI15LJu4YPH/UCPoSo/F47Gr1LIM0TE0lZA==",
       "dev": true,
       "workspaces": [
         "docs",
@@ -6384,7 +6402,6 @@
       "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-4.0.0.tgz",
       "integrity": "sha512-ySFolZQfw9FoDb3ed9d80Cm9f0+r7qj+HJkWjeD9RBfpxEVTlVhol+gvaQB/78WbwYfbnNh8nWHHBSlg072y6A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "loader-utils": "^3.2.0"
       }
@@ -8332,7 +8349,6 @@
       "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
       "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^1.6.0",
         "lit-element": "^3.3.0",
@@ -8344,7 +8360,6 @@
       "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
       "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.1.0",
         "@lit/reactive-element": "^1.3.0",
@@ -8356,7 +8371,6 @@
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
       "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -8366,7 +8380,6 @@
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.3.1.tgz",
       "integrity": "sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
       }
@@ -9963,7 +9976,6 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
       "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "icss-utils": "^5.0.0"
       },
@@ -10310,28 +10322,11 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.0.0-rc-fb9a90fa48-20240614",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0-rc-fb9a90fa48-20240614.tgz",
-      "integrity": "sha512-nvE3Gy+IOIfH/DXhkyxFVQSrITarFcQz4+shzC/McxQXEUSonpw2oDy/Wi9hdDtV3hlP12VYuDL95iiBREedNQ==",
-      "license": "MIT",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-confetti": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-confetti/-/react-confetti-6.1.0.tgz",
-      "integrity": "sha512-7Ypx4vz0+g8ECVxr88W9zhcQpbeujJAVqL14ZnXJ3I23mOI9/oBVTQ3dkJhUmB0D6XOtCZEM6N0Gm9PMngkORw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tween-functions": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=10.18"
-      },
-      "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.1 || ^18.0.0"
       }
     },
     "node_modules/react-docgen": {
@@ -10366,15 +10361,14 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.0.0-rc-fb9a90fa48-20240614",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0-rc-fb9a90fa48-20240614.tgz",
-      "integrity": "sha512-PoEsPe32F7KPLYOBvZfjylEI1B67N44PwY3lyvpmBkhlluLnLz0jH8q2Wg9YidAi6z0k3iUnNRm5x10wurzt9Q==",
-      "license": "MIT",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
+      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "dependencies": {
-        "scheduler": "0.25.0-rc-fb9a90fa48-20240614"
+        "scheduler": "^0.25.0"
       },
       "peerDependencies": {
-        "react": "19.0.0-rc-fb9a90fa48-20240614"
+        "react": "^19.0.0"
       }
     },
     "node_modules/react-error-boundary": {
@@ -10989,10 +10983,9 @@
       "optional": true
     },
     "node_modules/scheduler": {
-      "version": "0.25.0-rc-fb9a90fa48-20240614",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-fb9a90fa48-20240614.tgz",
-      "integrity": "sha512-HHqQ/SqbeiDfXXVKgNxTpbQTD4n7IUb4hZATvHjp03jr3TF7igehCyHdOjeYTrzIseLO93cTTfSb5f4qWcirMQ==",
-      "license": "MIT"
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA=="
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -11489,12 +11482,12 @@
       }
     },
     "node_modules/storybook": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.4.6.tgz",
-      "integrity": "sha512-J6juZSZT2u3PUW0QZYZZYxBq6zU5O0OrkSgkMXGMg/QrS9to9IHmt4FjEMEyACRbXo8POcB/fSXa3VpGe7bv3g==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.4.7.tgz",
+      "integrity": "sha512-RP/nMJxiWyFc8EVMH5gp20ID032Wvk+Yr3lmKidoegto5Iy+2dVQnUoElZb2zpbVXNHWakGuAkfI0dY1Hfp/vw==",
       "dev": true,
       "dependencies": {
-        "@storybook/core": "8.4.6"
+        "@storybook/core": "8.4.7"
       },
       "bin": {
         "getstorybook": "bin/index.cjs",
@@ -11529,6 +11522,56 @@
         "@storybook/theming": "^8.0.0",
         "fast-deep-equal": "^3.1.3",
         "memoizerific": "^1.11.3"
+      }
+    },
+    "node_modules/storybook-dark-mode/node_modules/@storybook/icons": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-1.2.12.tgz",
+      "integrity": "sha512-UxgyK5W3/UV4VrI3dl6ajGfHM4aOqMAkFLWe2KibeQudLf6NJpDrDMSHwZj+3iKC4jFU7dkKbbtH2h/al4sW3Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/storybook-dark-mode/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/storybook-dark-mode/node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/storybook-dark-mode/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/strict-uri-encode": {
@@ -12976,8 +13019,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tween-functions/-/tween-functions-1.2.0.tgz",
       "integrity": "sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==",
-      "dev": true,
-      "license": "BSD"
+      "dev": true
     },
     "node_modules/type-fest": {
       "version": "2.19.0",
@@ -13489,7 +13531,6 @@
       "resolved": "https://registry.npmjs.org/vite-css-modules/-/vite-css-modules-1.6.0.tgz",
       "integrity": "sha512-dh33owjQEZMCkEAL8Q/nFajnE+m+WNQxanWipdzvlttRNm90Z5fpjkxIr4hj6IAfCn/0Nko3wj1cZ5j1IRLBRQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@rollup/pluginutils": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -68,16 +68,16 @@
     "@biomejs/biome": "^1.9.4",
     "vitest": "^2.1.6",
     "@vitest/ui": "^2.1.6",
-    "storybook": "^8.4.6",
-    "@storybook/react": "^8.4.6",
-    "@storybook/react-vite": "^8.4.6",
-    "@storybook/blocks": "^8.4.6",
-    "@storybook/test": "^8.4.6",
-    "@storybook/addon-essentials": "^8.4.6",
-    "@storybook/addon-a11y": "^8.4.6",
-    "@storybook/addon-interactions": "^8.4.6",
-    "@storybook/addon-links": "^8.4.6",
-    "@storybook/addon-storysource": "^8.4.6",
+    "storybook": "^8.4.7",
+    "@storybook/react": "^8.4.7",
+    "@storybook/react-vite": "^8.4.7",
+    "@storybook/blocks": "^8.4.7",
+    "@storybook/test": "^8.4.7",
+    "@storybook/addon-essentials": "^8.4.7",
+    "@storybook/addon-a11y": "^8.4.7",
+    "@storybook/addon-interactions": "^8.4.7",
+    "@storybook/addon-links": "^8.4.7",
+    "@storybook/addon-storysource": "^8.4.7",
     "@storybook/addon-designs": "^8.0.4",
     "@chromatic-com/storybook": "^3.2.2",
     "storybook-dark-mode": "^4.0.2",
@@ -88,15 +88,15 @@
     "sass": "^1.81.0",
     "postcss-color-contrast": "^1.1.0",
     "lightningcss": "^1.28.2",
-    "@types/react": "npm:types-react@rc",
-    "@types/react-dom": "npm:types-react-dom@rc"
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0"
   },
   "dependencies": {
     "date-fns": "^4.1.0",
     "message-tag": "^0.10.0",
     "classnames": "^2.5.1",
-    "react": "^19.0.0-rc.1",
-    "react-dom": "^19.0.0-rc.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "react-error-boundary": "^4.1.2",
     "@floating-ui/react": "^0.26.28",
     "react-toastify": "^10.0.6",
@@ -104,12 +104,8 @@
     "react-hook-form": "^7.53.2",
     "optics-ts": "^2.4.1"
   },
-  "overrides": {
-    "@types/react": "npm:types-react@rc",
-    "@types/react-dom": "npm:types-react-dom@rc"
-  },
   "peerDependencies": {
-    "react": ">= 19.0.0-rc.1",
-    "react-dom": ">= 19.0.0-rc.1"
+    "react": ">= 19.0.0",
+    "react-dom": ">= 19.0.0"
   }
 }

--- a/package.json.js
+++ b/package.json.js
@@ -106,16 +106,16 @@ const packageConfig = {
     '@vitest/ui': '^2.1.6',
     
     // Storybook
-    'storybook': '^8.4.6',
-    '@storybook/react': '^8.4.6',
-    '@storybook/react-vite': '^8.4.6',
-    '@storybook/blocks': '^8.4.6',
-    '@storybook/test': '^8.4.6',
-    '@storybook/addon-essentials': '^8.4.6',
-    '@storybook/addon-a11y': '^8.4.6',
-    '@storybook/addon-interactions': '^8.4.6',
-    '@storybook/addon-links': '^8.4.6',
-    '@storybook/addon-storysource': '^8.4.6',
+    'storybook': '^8.4.7',
+    '@storybook/react': '^8.4.7',
+    '@storybook/react-vite': '^8.4.7',
+    '@storybook/blocks': '^8.4.7',
+    '@storybook/test': '^8.4.7',
+    '@storybook/addon-essentials': '^8.4.7',
+    '@storybook/addon-a11y': '^8.4.7',
+    '@storybook/addon-interactions': '^8.4.7',
+    '@storybook/addon-links': '^8.4.7',
+    '@storybook/addon-storysource': '^8.4.7',
     '@storybook/addon-designs': '^8.0.4',
     '@chromatic-com/storybook': '^3.2.2', // Chromatic integration for Storybook
     //'storybook-addon-pseudo-states': '^3.1.1',
@@ -136,10 +136,8 @@ const packageConfig = {
     'lightningcss': '^1.28.2',
     
     // React
-    //'@types/react': '^18.3.7',
-    //'@types/react-dom': '^18.2.22',
-    '@types/react': 'npm:types-react@rc',
-    '@types/react-dom': 'npm:types-react-dom@rc',
+    '@types/react': '^19.0.0',
+    '@types/react-dom': '^19.0.0',
   },
   
   // Dependencies needed when running the generated build
@@ -150,8 +148,8 @@ const packageConfig = {
     
     // React
     'classnames': '^2.5.1',
-    'react': '^19.0.0-rc.1',
-    'react-dom': '^19.0.0-rc.1',
+    'react': '^19.0.0',
+    'react-dom': '^19.0.0',
     'react-error-boundary': '^4.1.2',
     
     '@floating-ui/react': '^0.26.28',
@@ -162,14 +160,9 @@ const packageConfig = {
     
     'optics-ts': '^2.4.1',
   },
-  overrides: {
-    // See https://react.dev/blog/2024/04/25/react-19-upgrade-guide#installing
-    '@types/react': 'npm:types-react@rc',
-    '@types/react-dom': 'npm:types-react-dom@rc',
-  },
   peerDependencies: {
-    'react': '>= 19.0.0-rc.1',
-    'react-dom': '>= 19.0.0-rc.1',
+    'react': '>= 19.0.0',
+    'react-dom': '>= 19.0.0',
   },
 };
 

--- a/src/components/forms/context/Form/Form.stories.tsx
+++ b/src/components/forms/context/Form/Form.stories.tsx
@@ -21,7 +21,8 @@ type Story = StoryObj<FormArgs>;
 const FormWithState = (props: React.ComponentProps<typeof Form>) => {
   const action = async (previousState: unknown, formData: FormData): Promise<null> => {
     if (typeof props.action === 'function') {
-      return props.action?.(formData) ?? null;
+      await props.action?.(formData);
+      return null;
     }
     return null;
   };
@@ -77,7 +78,7 @@ export const Standard: Story = {
     //onSubmit: (event) => { event.preventDefault(); console.log('submit', event); },
     action: (formData) => {
       //console.log('action', formData.get('field-1'));
-      return [...formData.entries()].reduce(
+      const result = [...formData.entries()].reduce(
         (acc, [fieldKey, field]) => {
           if (Object.hasOwn(acc, fieldKey)) {
             console.warn(`Found duplicate entries for key ${fieldKey}`);
@@ -87,6 +88,7 @@ export const Standard: Story = {
         },
         {} as Record<string, unknown>,
       );
+      return; // FIXME: form actions now return type `void | Promise<void>`
     },
     children: (
       <>


### PR DESCRIPTION
Upgrades to React v19 stable, which was just released:

https://react.dev/blog/2024/12/05/react-19

I tried to see if I could remove the `--force` workaround for peer dependencies, however this is still not possible due to the following two dependencies:

- `@storybook/addon-designs`: Open issue for it [here](https://github.com/storybookjs/addon-designs/issues/246).
- `vite-css-modules`: This one actually doesn't conflict with React, but with Vite v6. No issue for it yet I believe, but related discussion [here](https://github.com/privatenumber/vite-css-modules/issues/13). Perhaps we should consider downgrading to Vite v5 for now?