### PR TITLE
Only run Chromatic on master by default

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -1,6 +1,9 @@
 name: "Chromatic"
 
-on: push
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   chromatic:


### PR DESCRIPTION
Running Chromatic on every push is raking up usage limits too fast, so I'm limiting it to master only. Feature branches can still request a Chromatic build, but must be done manually.