### PR TITLE
Fix fractional px value rounding issues

### DIFF
--- a/src/components/containers/Accordion/Accordion.module.scss
+++ b/src/components/containers/Accordion/Accordion.module.scss
@@ -13,10 +13,10 @@
     
     .bk-accordion__item + .bk-accordion__item {
       --bk-disclosure-border-radius-top: 0;
-      border-top-width: 0;
     }
     .bk-accordion__item:has(+ .bk-accordion__item) {
       --bk-disclosure-border-radius-bottom: 0;
+      border-bottom-width: 0;
     }
   }
 }

--- a/src/components/containers/Banner/Banner.module.scss
+++ b/src/components/containers/Banner/Banner.module.scss
@@ -16,7 +16,7 @@
     overflow: hidden; // Banners shouldn't scroll (max height on a banner doesn't really make sense)
     
     padding-block: bk.$spacing-2;
-    padding-inline: bk.$spacing-4 - bk.$radius-2;
+    padding-inline: calc(bk.$spacing-4 - bk.$radius-2);
     padding-inline-start: var(--bk-banner-indent); // Indent all of the content (e.g. for when the message wraps)
     
     border: bk.$size-1 var(--bk-banner-color-foreground) solid;

--- a/src/components/containers/Dialog/Dialog.module.scss
+++ b/src/components/containers/Dialog/Dialog.module.scss
@@ -35,7 +35,7 @@
       top: 0;
       z-index: 1;
       
-      padding-block: var(--bk-dialog-padding-block) (bk.$spacing-7 / 2);
+      padding-block: var(--bk-dialog-padding-block) calc(bk.$spacing-7 / 2);
       padding-inline: var(--bk-dialog-padding-inline);
       background: var(--bk-dialog-background-color);
       
@@ -58,7 +58,7 @@
     .bk-dialog__content {
       flex: 1;
       
-      margin-block: (bk.$spacing-7 / 2) (bk.$spacing-7 / 2);
+      margin-block: calc(bk.$spacing-7 / 2) calc(bk.$spacing-7 / 2);
       padding-inline: var(--bk-dialog-padding-inline);
     }
     
@@ -67,7 +67,7 @@
       bottom: 0;
       z-index: 1;
       
-      padding-block: (bk.$spacing-7 / 2) bk.$spacing-9;
+      padding-block: calc(bk.$spacing-7 / 2) bk.$spacing-9;
       padding-inline: var(--bk-dialog-padding-inline);
       // In Figma, actions have an indent. But that might be only if the content itself has an indent, need to check.
       //padding-inline-start: calc(var(--bk-dialog-padding-inline) + bk.$spacing-8);

--- a/src/components/forms/controls/DatePicker/DatePicker.module.scss
+++ b/src/components/forms/controls/DatePicker/DatePicker.module.scss
@@ -13,7 +13,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    margin-right: -$caret-width;
+    margin-right: calc(-1 * $caret-width);
   }
 
   .bk-date-picker--input {
@@ -25,7 +25,7 @@
     width: $caret-width;
     height: $caret-width;
     position: relative;
-    left: -$caret-width;
+    left: calc(-1 * $caret-width);
     top: bk.rem-from-px(-1);
   }
 

--- a/src/components/forms/fields/CheckboxField/CheckboxField.module.scss
+++ b/src/components/forms/fields/CheckboxField/CheckboxField.module.scss
@@ -14,7 +14,6 @@
       margin-bottom: bk.$spacing-1;
 
       .bk-checkbox-field__title__icon {
-        font-size: 18px;
         margin-left: bk.$spacing-1;
       }
 

--- a/src/components/forms/fields/RadioField/RadioField.module.scss
+++ b/src/components/forms/fields/RadioField/RadioField.module.scss
@@ -14,7 +14,6 @@
       margin-bottom: bk.$spacing-1;
 
       .bk-radio-field__title__icon {
-        font-size: 18px;
         margin-left: bk.$spacing-1;
       }
 

--- a/src/styling/defs.scss
+++ b/src/styling/defs.scss
@@ -59,5 +59,5 @@
 }
 
 @function rem-from-px($size-in-px) {
-  @return math.div($size-in-px, 14) * 1rem;
+  @return round(math.div($size-in-px, 14) * 1rem, 1px);
 }

--- a/src/styling/global/global.scss
+++ b/src/styling/global/global.scss
@@ -38,7 +38,7 @@
     // https://royalfig.github.io/fluid-typography-calculator
     //font-size: clamp(0.8rem, 0.76rem + 0.19999999999999996vw, 1rem);
     // https://utopia.fyi/type/calculator?c=320,12,1.2,1440,14,1.25,4,2,&s=0.75|0.5|0.25,1.5|2|3|4|6,s-l&g=s,l,xl,12
-    font-size: clamp(0.75rem, 0.7143rem + 0.1786vi, 0.875rem); // 1rem ~ 14px at 1440px max viewport size
+    font-size: round(clamp(0.75rem, 0.7143rem + 0.1786vi, 0.875rem), 1px); // 1rem ~ 14px at 1440px max viewport size
     
     /* https://css-tricks.com/how-to-tame-line-height-in-css/ */
     line-height: 1.6;

--- a/src/styling/global/reset.scss
+++ b/src/styling/global/reset.scss
@@ -7,7 +7,6 @@
 @mixin styles {
   @include meta.load-css('../lib/reset.css');
   
-  
   /* Custom reset overrides */
   
   // :focus-visible {

--- a/src/styling/variables.scss
+++ b/src/styling/variables.scss
@@ -46,24 +46,24 @@ $sizing-xxl: $sizing-9 !default;
 
 // NEW
 // Reference: 1rem ~ 14px (at max 1440px size, and with default 1rem=16px browser font size)
-$spacing-1: math.div(4, 14) * 1rem !default; // ~4px
-$spacing-2: math.div(8, 14) * 1rem !default; // ~8px
-$spacing-3: math.div(12, 14) * 1rem !default; // ~12px
-$spacing-4: math.div(16, 14) * 1rem !default; // ~16px
-$spacing-5: math.div(18, 14) * 1rem !default; // ~18px
-$spacing-6: math.div(20, 14) * 1rem !default; // ~20px
-$spacing-7: math.div(24, 14) * 1rem !default; // ~24px
-$spacing-8: math.div(32, 14) * 1rem !default; // ~32px
-$spacing-9: math.div(40, 14) * 1rem !default; // ~40px
-$spacing-10: math.div(48, 14) * 1rem !default; // ~48px
-$spacing-11: math.div(64, 14) * 1rem !default; // ~64px
-$spacing-12: math.div(80, 14) * 1rem !default; // ~80px
-$spacing-13: math.div(96, 14) * 1rem !default; // ~96px
-$spacing-14: math.div(128, 14) * 1rem !default; // ~128px
-$spacing-15: math.div(160, 14) * 1rem !default; // ~160px
-$spacing-16: math.div(192, 14) * 1rem !default; // ~192px
-$spacing-17: math.div(224, 14) * 1rem !default; // ~224px
-$spacing-18: math.div(256, 14) * 1rem !default; // ~256px
+$spacing-1: round(math.div(4, 14) * 1rem, 1px) !default; // ~4px
+$spacing-2: round(math.div(8, 14) * 1rem, 1px) !default; // ~8px
+$spacing-3: round(math.div(12, 14) * 1rem, 1px) !default; // ~12px
+$spacing-4: round(math.div(16, 14) * 1rem, 1px) !default; // ~16px
+$spacing-5: round(math.div(18, 14) * 1rem, 1px) !default; // ~18px
+$spacing-6: round(math.div(20, 14) * 1rem, 1px) !default; // ~20px
+$spacing-7: round(math.div(24, 14) * 1rem, 1px) !default; // ~24px
+$spacing-8: round(math.div(32, 14) * 1rem, 1px) !default; // ~32px
+$spacing-9: round(math.div(40, 14) * 1rem, 1px) !default; // ~40px
+$spacing-10: round(math.div(48, 14) * 1rem, 1px) !default; // ~48px
+$spacing-11: round(math.div(64, 14) * 1rem, 1px) !default; // ~64px
+$spacing-12: round(math.div(80, 14) * 1rem, 1px) !default; // ~80px
+$spacing-13: round(math.div(96, 14) * 1rem, 1px) !default; // ~96px
+$spacing-14: round(math.div(128, 14) * 1rem, 1px) !default; // ~128px
+$spacing-15: round(math.div(160, 14) * 1rem, 1px) !default; // ~160px
+$spacing-16: round(math.div(192, 14) * 1rem, 1px) !default; // ~192px
+$spacing-17: round(math.div(224, 14) * 1rem, 1px) !default; // ~224px
+$spacing-18: round(math.div(256, 14) * 1rem, 1px) !default; // ~256px
 
 // these sizes do not match Figma variables
 $size-1: math.div(1, 14) * 1rem !default; // ~1px

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -79,7 +79,8 @@ export default {
     ],
     
     // Expressions
-    //...
+    // Workaround for `round()`, re-enable once https://github.com/stylelint-scss/stylelint-scss/pull/1097 lands
+    'scss/no-global-function-names': null,
     
     // CSS extensions (e.g. CSS modules, or future CSS)
     //'property-no-unknown': [true, { ignoreProperties: [] }],


### PR DESCRIPTION
Due to the fluid typography we use, most lengths end up being some fraction of a px. Browsers will round this value, but this can cause some visual glitches. For example:

![image](https://github.com/user-attachments/assets/fc377331-ddbc-4be6-bbff-8045d8e21616)

In `Dialog`, see the very bottom of the dialog where one pixel row of text is bleeding through, despite the footer being positioned with `bottom: 0`.

![image](https://github.com/user-attachments/assets/a9729cfd-dfad-4113-8807-09339ca6894a)

Here in `Accordion`, the 1px horizontal border on “Title 2” is hidden due to overlap from the “Title 3” having shifted upwards slightly. This is despite all these elements being in a basic flex box with a `gap: 0`.

Nowadays, browsers support the CSS `round()` function. This is baseline as of May 2024. Using this function we can round our values to the nearest pixel.

For some thing slightly more advanced, we can even make use of the `calc-size` function to round a width/height of `auto`. (But `calc-size` is not yet well enough supported, we can't use it.) See [here](https://css-tip.com/pixel-rounding). This doesn't seem necessary though, just the `round()` on the `rem` values seems sufficient to fix all the rounding issues I've come across.