### PR TITLE
Fix Biome linter errors + TS errors + accessibility violations

### DIFF
--- a/.github/workflows/storybook_test.yaml
+++ b/.github/workflows/storybook_test.yaml
@@ -5,11 +5,11 @@ name: Storybook Tests
 
 on:
   push:
-    branches: [ "**" ]
+    branches:
+      - "master"
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:

--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -14,6 +14,9 @@ const config: TestRunnerConfig = {
     await injectAxe(page);
   },
   async postVisit(page, context) {
+    // Workaround for https://github.com/dequelabs/axe-core/issues/3426
+    await new Promise(resolve => setTimeout(resolve, 200));
+    
     // Get the entire context of a story, including parameters, args, argTypes, etc.
     const storyContext = await getStoryContext(page, context);
     

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,8 +19,8 @@
   "editor.trimAutoWhitespace": false,
   "files.eol": "\n",
   "javascript.preferences.quoteStyle": "single",
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.tsdk": "node_modules/typescript/lib", // Use the TypeScript SDK from the current project
   "typescript.preferences.autoImportFileExcludePatterns": [
     "storybook/internal/**/*"
-  ], // Use the TypeScript SDK from the current project
+  ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,8 @@
   "editor.trimAutoWhitespace": false,
   "files.eol": "\n",
   "javascript.preferences.quoteStyle": "single",
-  "typescript.tsdk": "node_modules/typescript/lib", // Use the TypeScript SDK from the current project
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.preferences.autoImportFileExcludePatterns": [
+    "storybook/internal/**/*"
+  ], // Use the TypeScript SDK from the current project
 }

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -34,7 +34,7 @@
     "rules": {
       "recommended": true,
       "correctness": {
-        "useExhaustiveDependencies": "off"
+        //"useExhaustiveDependencies": "off"
       },
       "complexity": {
         "noBannedTypes": "off",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -34,7 +34,7 @@
     "rules": {
       "recommended": true,
       "correctness": {
-        //"useExhaustiveDependencies": "off"
+        "useExhaustiveDependencies": "off"
       },
       "complexity": {
         "noBannedTypes": "off",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -23,19 +23,24 @@
   },
   "linter": {
     "enabled": true,
-    "include": ["app/**/*", "src/**/*", "tests/**/*"],
+    "include": ["app", "src", "tests"],
     
     "ignore": [
       "node_modules",
+      "dist",
       "src/components/tables/MultiSearch/MultiSearch.tsx", // Ignore for now (need to focus on type errors first)
-      "tests/installation/**/*"
-  ],
+      "tests/installation"
+    ],
     "rules": {
       "recommended": true,
+      "correctness": {
+        //"useExhaustiveDependencies": "off"
+      },
       "complexity": {
         "noBannedTypes": "off",
         "noForEach": "off",
-        "useOptionalChain": "off"
+        "useOptionalChain": "off",
+        "useLiteralKeys": "off"
       },
       "style": {
         "useImportType": "off",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "test": "npm run check:types && npm run lint:style",
     "test-ui": "vitest --ui",
     "coverage": "vitest run --coverage",
-    "test:storybook": "test-storybook --failOnConsole --browsers chromium",
+    "test:storybook": "test-storybook --failOnConsole --browsers chromium --maxWorkers=1",
     "test:storybook-ci": "\n      npx playwright install --with-deps chromium        && npx concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\"          \"npm run storybook:build --quiet && npx http-server storybook-static --port 6006 --silent\"          \"npx wait-on tcp:6006 && npm run test:storybook\"\n    ",
     "start": "npm run storybook:serve",
     "prepare": "npm run build"

--- a/package.json.js
+++ b/package.json.js
@@ -85,7 +85,8 @@ const packageConfig = {
     
     // Browser automation tests
     // https://github.com/storybookjs/test-runner?tab=readme-ov-file#2-running-against-locally-built-storybooks-in-ci
-    'test:storybook': 'test-storybook --failOnConsole --browsers chromium', // For text only: FORCE_COLOR=false
+    'test:storybook': 'test-storybook --failOnConsole --browsers chromium --maxWorkers=1', // For text only: FORCE_COLOR=false
+    // Note: the following assumes `localhost:6006` is free, so don't run it if a dev server is already running
     'test:storybook-ci': `
       npx playwright install --with-deps chromium\
         && npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue"\

--- a/src/components/actions/Button/Button.module.scss
+++ b/src/components/actions/Button/Button.module.scss
@@ -32,7 +32,7 @@
     align-items: center;
     gap: 0.3ch;
     
-    @include bk.font(bk.$font-family-display, bk.$font-weight-medium);
+    @include bk.font(bk.$font-family-display, bk.$font-weight-semibold);
     /* letter-spacing: 0.1ch; */
     text-transform: uppercase;
     

--- a/src/components/actions/Link/Link.stories.tsx
+++ b/src/components/actions/Link/Link.stories.tsx
@@ -5,9 +5,10 @@
 import * as React from 'react';
 
 import type { Meta, StoryObj } from '@storybook/react';
+import { DummyLink } from '../../../util/storybook/StorybookLink.tsx';
+import { OverflowTester } from '../../../util/storybook/OverflowTester.tsx';
 
 import { Link } from './Link.tsx';
-import { OverflowTester } from '../../../util/storybook/OverflowTester.tsx';
 
 
 type LinkArgs = React.ComponentProps<typeof Link>;
@@ -45,7 +46,7 @@ export const Descenders: Story = {
 export const Scroll: Story = {
   render: (args) => (
     <>
-      <a id="anchor" href="/" onClick={evt => { evt.preventDefault(); }}>Anchor</a>
+      <DummyLink id="anchor">Anchor</DummyLink>
       <OverflowTester openDefault/>
       <Link {...args} href="#anchor"/>
       <OverflowTester openDefault/>

--- a/src/components/containers/Banner/Banner.tsx
+++ b/src/components/containers/Banner/Banner.tsx
@@ -149,7 +149,7 @@ export const Banner = Object.assign(
         )}
       >
         {/* Apply `bk-theme--light` on all children (but not the box itself). */}
-        <header className={cx('bk-theme--light', cl['bk-banner__header'])}>
+        <div className={cx('bk-theme--light', cl['bk-banner__header'])}>
           <div className={cx(cl['bk-banner__header__text'])}>
             <strong className={cx(cl['bk-banner__title'])}>
               <BannerVariantIcon variant={variant} className={cx(cl['bk-banner__title__icon'])}/>
@@ -174,7 +174,7 @@ export const Banner = Object.assign(
               </ActionIcon>
             }
           </div>
-        </header>
+        </div>
         
         {!compact && children &&
           <article className={cx('bk-body-text', 'bk-theme--light', cl['bk-banner__message'])}>{children}</article>

--- a/src/components/containers/Banner/Banner.tsx
+++ b/src/components/containers/Banner/Banner.tsx
@@ -45,10 +45,8 @@ const ActionButton = (props: ActionButtonProps) => {
     <Button trimmed
       {...props}
       className={cx(cl['bk-banner__action'], cl['bk-banner__action--button'], props.className)}
-      onClick={event => {
-        event.stopPropagation(); // Prevent this from triggering any click handlers on the Banner itself (e.g. toasts)
-        props.onClick?.(event);
-      }}
+      // Prevent clicks from triggering any click handlers on the Banner itself (e.g. to prevent toast dismissal)
+      onClick={event => { event.stopPropagation(); props.onClick?.(event); }}
     />
   );
 };
@@ -69,10 +67,8 @@ const ActionIcon = ({ tooltip, ...buttonProps }: ActionIconProps) => {
       <Button trimmed
         {...buttonProps}
         className={cx(cl['bk-banner__action'], cl['bk-banner__action--icon'], buttonProps.className)}
-        onClick={event => {
-          event.stopPropagation(); // Prevent this from triggering any click handlers on the Banner itself (e.g. toasts)
-          buttonProps.onClick?.(event);
-        }}
+        // Prevent clicks from triggering any click handlers on the Banner itself (e.g. to prevent toast dismissal)
+        onClick={event => { event.stopPropagation(); buttonProps.onClick?.(event); }}
       />
     </TooltipProvider>
   );

--- a/src/components/forms/controls/Checkbox/Checkbox.stories.tsx
+++ b/src/components/forms/controls/Checkbox/Checkbox.stories.tsx
@@ -22,7 +22,9 @@ export default {
   tags: ['autodocs'],
   argTypes: {
   },
-  args: {},
+  args: {
+    'aria-label': 'Test checkbox',
+  },
   decorators: [
     Story => <form onSubmit={event => { event.preventDefault(); }}><Story/></form>,
   ],

--- a/src/components/forms/controls/DateTimePicker/DateTimePicker.tsx
+++ b/src/components/forms/controls/DateTimePicker/DateTimePicker.tsx
@@ -60,12 +60,14 @@ export const DateTimePicker = (props: DateTimePickerProps) => {
       )}
     >
       <DatePicker
+        aria-label="Date input"
         selected={date}
         onChange={onChange}
         dateFormat={dateFormat}
         placeholderText={placeholderText}
       />
       <TimePicker
+        aria-label="Time input"
         time={time}
         onUpdate={onTimeUpdate}
         className={cx(cl['bk-date-time-picker--time-picker'])}

--- a/src/components/forms/controls/Input/Input.stories.tsx
+++ b/src/components/forms/controls/Input/Input.stories.tsx
@@ -45,11 +45,14 @@ export const InvalidInput: Story = {
   async play({ canvasElement }) {
     const canvas = within(canvasElement);
     const input = canvas.getByPlaceholderText('Example');
+    const form = input.closest('form');
+    if (!form) { throw new Error(`Missing <form> element`); }
+    
     await delay(100);
     await userEvent.type(input, 'invalid');
     await delay(100);
     await userEvent.keyboard('{Enter}');
-    await fireEvent.submit(input.closest('form')!);
-    await userEvent.click(input.closest('form')!);
+    await fireEvent.submit(form);
+    await userEvent.click(form);
   },  
 };

--- a/src/components/forms/controls/Radio/Radio.stories.tsx
+++ b/src/components/forms/controls/Radio/Radio.stories.tsx
@@ -22,7 +22,9 @@ export default {
   tags: ['autodocs'],
   argTypes: {
   },
-  args: {},
+  args: {
+    'aria-label': 'Test radio button',
+  },
   decorators: [
     Story => <form onSubmit={event => { event.preventDefault(); }}><Story/></form>,
   ],

--- a/src/components/forms/controls/Select/Select.tsx
+++ b/src/components/forms/controls/Select/Select.tsx
@@ -65,9 +65,8 @@ export const Option = (props: OptionProps) => {
           cl['bk-select__option'],
           propsRest.className,
         )}
-        {...getItemProps({
-          onClick: () => { selectOption(option); },
-        })}
+        {...getItemProps()}
+        onPress={() => { selectOption(option); }}
       >
         {label ?? propsRest.children}
       </Button>

--- a/src/components/forms/controls/Switch/Switch.stories.tsx
+++ b/src/components/forms/controls/Switch/Switch.stories.tsx
@@ -17,6 +17,7 @@ export default {
   tags: ['autodocs'],
   argTypes: {},
   args: {
+    'aria-label': 'Test switch',
     defaultChecked: true,
   },
   decorators: [

--- a/src/components/forms/controls/TimePicker/TimePicker.stories.tsx
+++ b/src/components/forms/controls/TimePicker/TimePicker.stories.tsx
@@ -33,7 +33,7 @@ export const TimePickerStory: Story = {
 
     return (
       <div>
-        <TimePicker time={time} onUpdate={setTime}/>
+        <TimePicker aria-label="Example time picker" time={time} onUpdate={setTime}/>
         <p>
           The selected time is: {time.hours}:{time.minutes}
         </p>

--- a/src/components/navigations/Stepper/Stepper.module.scss
+++ b/src/components/navigations/Stepper/Stepper.module.scss
@@ -8,53 +8,62 @@
   .bk-stepper {
     @include bk.component-base(bk-stepper);
     
+    --bk-stepper-indicator-size: #{bk.rem-from-px(28)};
+    display: flex;
+    
+    > ol {
+      display: contents;
+    }
+    
     &.bk-stepper--horizontal {
-      display: flex;
-      gap: bk.$spacing-9;
+      flex-direction: row;
+      column-gap: bk.$spacing-9;
     }
     
     &.bk-stepper--vertical {
-      .bk-stepper__item {
-        &:not(:first-child) {
-          margin-top: bk.$spacing-9;
+      flex-direction: column;
+      row-gap: bk.$spacing-9;
       
-          .bk-stepper__item__circle {
-            &::before {
-              position: absolute;
-              content: '';
-              width: 0;
-              height: bk.$spacing-9;
-              top: -42px;
-              left: 50%;
-              border: 0.5px solid #{bk.$theme-stepper-border-disabled};
-            }
-          }
+      // Draw a line between subsequent items
+      li + li .bk-stepper__item__indicator {
+        &::before {
+          content: '';
+          position: absolute;
+          top: calc(-1 * bk.$spacing-9 - bk.$size-2);
+          left: calc(50% - bk.$size-2 / 2);
+          width: 0;
+          height: bk.$spacing-9;
+          border-left: bk.$size-2 solid bk.$theme-stepper-border-disabled;
         }
       }
     }
     
     .bk-stepper__item {
-      display: flex;
-      align-items: center;
-      color: #{bk.$theme-stepper-text-disabled};
       cursor: pointer;
       
-      .bk-stepper__item__circle {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        position: relative;
+      display: flex;
+      align-items: center;
+      color: bk.$theme-stepper-text-disabled;
+      
+      .bk-stepper__item__indicator {
+        position: relative; // Needed for the vertical line `position: absolute`
+        flex-shrink: 0;
+        
         margin-right: bk.$spacing-3;
-        border: 2px solid #{bk.$theme-stepper-border-disabled};
+        aspect-ratio: 1;
+        width: var(--bk-stepper-indicator-size);
+        
+        border: bk.$size-2 solid #{bk.$theme-stepper-border-disabled};
         border-radius: 50%;
-        width: 28px;
-        height: 28px;
         font-weight: bk.$font-weight-bold;
         font-size: bk.$font-size-m;
-      }
-      
-      .bk-stepper__item__circle__icon {
-        font-size: bk.$font-size-xs;
+        
+        display: grid;
+        place-content: center;
+        
+        .bk-stepper__item__indicator__icon {
+          font-size: bk.$font-size-xs;
+        }
       }
       
       .bk-stepper__item__title {
@@ -65,22 +74,26 @@
         margin-left: bk.$spacing-2;
         font-size: bk.$font-size-xs;
       }
-             
-      &[aria-selected="true"] {
-        color: #{bk.$theme-stepper-text-selected};
-        
-        .bk-stepper__item__circle {
-          border-color: #{bk.$theme-stepper-border-default};
-          background-color: #{bk.$theme-stepper-background-default};
-          color: #{bk.$theme-stepper-text-selected-number};
-        }
-      }
+    }
+    
+    // Any steps we've already visited
+    .bk-stepper__item--checked {
+      color: bk.$theme-stepper-text-selected;
       
-      &.bk-stepper__item--checked {
-        color: #{bk.$theme-stepper-text-selected};
+      .bk-stepper__item__indicator {
+        border-color: bk.$theme-stepper-border-default;
+      }
+    }
+    
+    // The currently active step
+    [aria-current="true"] {
+      .bk-stepper__item {
+        color: bk.$theme-stepper-text-selected;
         
-        .bk-stepper__item__circle {
-          border-color: #{bk.$theme-stepper-border-default};
+        .bk-stepper__item__indicator {
+          border-color: bk.$theme-stepper-border-default;
+          background-color: bk.$theme-stepper-background-default;
+          color: bk.$theme-stepper-text-selected-number;
         }
       }
     }

--- a/src/components/navigations/Stepper/Stepper.stories.tsx
+++ b/src/components/navigations/Stepper/Stepper.stories.tsx
@@ -6,7 +6,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import * as React from 'react';
 
-import { Stepper, Step } from './Stepper.tsx';
+import { type Step, Stepper } from './Stepper.tsx';
 
 
 type StepperArgs = React.ComponentProps<typeof Stepper>;
@@ -27,7 +27,7 @@ export default {
 const defaultSteps: Step[] = [1,2,3,4].map(index => { 
   return {
     stepKey: `${index}`,
-    title: `Step${index}`,
+    title: `Step ${index}`,
     isOptional: index === 4,
   };
 });

--- a/src/components/navigations/Tabs/Tabs.stories.tsx
+++ b/src/components/navigations/Tabs/Tabs.stories.tsx
@@ -36,13 +36,12 @@ const defaultTabOptions: DefaultTabOption[] = [1,2,3,4].map(index => {
 
 type TabWithTriggerProps = React.PropsWithChildren<Partial<TabsArgs>> & {
   options?: undefined | Array<DefaultTabOption>,
-  defaultActiveTabKey: string,
+  defaultActiveTabKey?: undefined | string,
 };
 const TabWithTrigger = (props: TabWithTriggerProps) => {
   const { options = defaultTabOptions, defaultActiveTabKey, ...tabContext } = props;
   
-  const [activeTabKey, setActiveTabKey] = React.useState<null | string>(defaultActiveTabKey ?? null);
-  if (activeTabKey === null) { throw new Error(`Missing defaultActiveTabKey prop`); }
+  const [activeTabKey, setActiveTabKey] = React.useState<undefined | string>(defaultActiveTabKey);
   
   return (
     <Tabs onSwitch={setActiveTabKey} activeKey={activeTabKey} {...tabContext}>

--- a/src/components/navigations/Tabs/Tabs.stories.tsx
+++ b/src/components/navigations/Tabs/Tabs.stories.tsx
@@ -35,12 +35,15 @@ const defaultTabOptions: DefaultTabOption[] = [1,2,3,4].map(index => {
 });
 
 type TabWithTriggerProps = React.PropsWithChildren<Partial<TabsArgs>> & {
-  options: DefaultTabOption[],
+  options?: undefined | Array<DefaultTabOption>,
   defaultActiveTabKey: string,
 };
 const TabWithTrigger = (props: TabWithTriggerProps) => {
   const { options = defaultTabOptions, defaultActiveTabKey, ...tabContext } = props;
-  const [activeTabKey, setActiveTabKey] = React.useState<string>(defaultActiveTabKey);
+  
+  const [activeTabKey, setActiveTabKey] = React.useState<null | string>(defaultActiveTabKey ?? null);
+  if (activeTabKey === null) { throw new Error(`Missing defaultActiveTabKey prop`); }
+  
   return (
     <Tabs onSwitch={setActiveTabKey} activeKey={activeTabKey} {...tabContext}>
       {options.map(tab => {
@@ -58,20 +61,21 @@ const TabWithTrigger = (props: TabWithTriggerProps) => {
     </Tabs>
   );
 };
+type StoryWithTrigger = StoryObj<TabWithTriggerProps>;
 
-const BaseStory: Story = {
+const BaseStory: StoryWithTrigger = {
   args: {},
   render: (args) => <TabWithTrigger {...args} />,
 };
 
-export const Standard: Story = {
-    ...BaseStory,
+export const Standard: StoryWithTrigger = {
+  ...BaseStory,
   name: 'Standard',
   args: { ...BaseStory.args },
 };
 
-export const StandardHover: Story = {
-    ...BaseStory,
+export const StandardHover: StoryWithTrigger = {
+  ...BaseStory,
   name: 'Standard [hover]',
   args: {
     ...BaseStory.args,
@@ -87,8 +91,8 @@ export const StandardHover: Story = {
   },
 };
 
-export const StandardFocus: Story = {
-    ...BaseStory,
+export const StandardFocus: StoryWithTrigger = {
+  ...BaseStory,
   name: 'Standard [focus]',
   args: {
     ...BaseStory.args,

--- a/src/components/navigations/Tabs/Tabs.tsx
+++ b/src/components/navigations/Tabs/Tabs.tsx
@@ -58,7 +58,7 @@ export const Tabs = (props: TabsProps) => {
   };
   
   const renderActive = (tab: TabElement) => {
-    let tabElement;
+    let tabElement: React.ReactNode;
     if (typeof tab.props.render === 'function') {
       tabElement = tab.props.render();
     } else {

--- a/src/components/navigations/Tabs/Tabs.tsx
+++ b/src/components/navigations/Tabs/Tabs.tsx
@@ -83,10 +83,11 @@ export const Tabs = (props: TabsProps) => {
     <div
       {...propsRest}
       role="tablist"
-      className={cx({
-        bk: true,
-        [cl['bk-tabs']]: !unstyled,
-      }, propsRest.className)}
+      className={cx(
+        'bk',
+        { [cl['bk-tabs']]: !unstyled },
+        propsRest.className,
+      )}
     >
       <ul className={cx(cl['bk-tabs__switcher'])}>
         {tabs.map(tab => {
@@ -94,13 +95,13 @@ export const Tabs = (props: TabsProps) => {
           const isActive = tab.props.tabKey === activeKey;
           return (
             <li
+              key={tab.props.tabKey}
               role="tab"
               tabIndex={0}
-              aria-selected={isActive ? 'true': 'false'}
+              aria-selected={isActive}
               data-tab={tab.props.tabKey}
-              key={tab.props.tabKey}
               className={cx(cl['bk-tabs__switcher__tab'],tab.props.className)}
-              onClick={() => { onSwitch(tab.props.tabKey); }}
+              onClick={() => { onSwitch(tab.props.tabKey); }} // FIXME: add a Button and use that instead
             >
               {tab.props.title}
             </li>

--- a/src/components/navigations/Tabs/Tabs.tsx
+++ b/src/components/navigations/Tabs/Tabs.tsx
@@ -30,7 +30,7 @@ export type TabsProps = React.PropsWithChildren<ComponentProps<'div'> & {
   unstyled?: undefined | boolean,
   
   /** Active key of tab. */
-  activeKey?: string,
+  activeKey?: undefined | string,
   
   /** Callback executed when active tab is changed. */
   onSwitch: (tabKey: TabKey) => void,

--- a/src/components/overlays/DialogModal/DialogModal.stories.tsx
+++ b/src/components/overlays/DialogModal/DialogModal.stories.tsx
@@ -9,6 +9,7 @@ import { LoremIpsum } from '../../../util/storybook/LoremIpsum.tsx';
 
 import { notify } from '../ToastProvider/ToastProvider.tsx';
 import { Button } from '../../actions/Button/Button.tsx';
+import { AccountSelector } from '../../../layouts/AppLayout/Header/AccountSelector.tsx';
 
 import { DialogModal } from './DialogModal.tsx';
 
@@ -111,6 +112,18 @@ export const DialogModalWithToast: Story = {
             Trigger toast notification
           </Button>
         </DialogModal>
+      </>
+    ),
+  },
+};
+
+export const DialogModalWithDropdown: Story = {
+  args: {
+    title: 'Modal with a dropdown',
+    children: (
+      <>
+        <p>The following dropdown menu should overlay the modal (and not be cut off).</p>
+        <AccountSelector/>
       </>
     ),
   },

--- a/src/components/overlays/DropdownMenu/DropdownMenu.module.scss
+++ b/src/components/overlays/DropdownMenu/DropdownMenu.module.scss
@@ -13,6 +13,8 @@
     --bk-dropdown-menu-transition-duration: 150ms;
     
     overflow: hidden;
+    /* stylelint-disable-next-line declaration-property-value-disallowed-list */
+    overflow-y: auto;
     
     min-width: $bk-dropdown-menu-min-width;
     max-height: 18rem;
@@ -74,7 +76,7 @@
       &:hover {
         background: bk.$theme-dropdown-menu-menu-background-hover;
       }
-      &[aria-selected="true"] {
+      &:has(> [aria-selected="true"]) {
         background: bk.$theme-dropdown-menu-menu-background-hover;
         box-shadow: inset 5px 0 bk.$theme-dropdown-menu-menu-tab-default;
       }
@@ -94,9 +96,8 @@
         align-items: center;
         gap: bk.$spacing-3;
         
-        .bk-dropdown-menu__item__icon {
-          font-size: 1.4em;
-        }
+        .bk-dropdown-menu__item__icon { font-size: 1.4em; }
+        .bk-dropdown-menu__item__label { --keep: ; }
         
         @include bk.focus-inset;
       }

--- a/src/components/overlays/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/components/overlays/DropdownMenu/DropdownMenu.stories.tsx
@@ -21,6 +21,7 @@ export default {
   argTypes: {
   },
   args: {
+    label: 'Test dropdown',
   },
   render: (args) => <DropdownMenu {...args}/>,
 } satisfies Meta<DropdownMenuArgs>;

--- a/src/components/overlays/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/overlays/DropdownMenu/DropdownMenu.tsx
@@ -76,7 +76,7 @@ export const Action = (props: ActionProps) => {
           cl['bk-dropdown-menu__item--action'],
           propsRest.className,
         )}
-        onClick={() => { onActivate(context); }}
+        onPress={() => { onActivate(context); }}
       >
         {icon && <Icon icon={icon}/>}
         {label ?? propsRest.children}
@@ -121,7 +121,7 @@ export const Option = (props: OptionProps) => {
           cl['bk-dropdown-menu__item--option'],
           propsRest.className,
         )}
-        onClick={() => { selectOption(option); }}
+        onPress={() => { selectOption(option); }}
       >
         {icon && <Icon icon={icon} className={cl['bk-dropdown-menu__item__icon']}/>}
         <span className={cl['bk-dropdown-menu__item__label']}>{label ?? propsRest.children}</span>

--- a/src/components/overlays/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/overlays/DropdownMenu/DropdownMenu.tsx
@@ -4,7 +4,6 @@
 
 import * as React from 'react';
 import { classNames as cx, type ComponentProps } from '../../../util/componentUtil.ts';
-import { useScroller } from '../../../layouts/util/Scroller.tsx';
 
 import { type IconName, Icon } from '../../graphics/Icon/Icon.tsx';
 import { Button } from '../../actions/Button/Button.tsx';
@@ -12,8 +11,12 @@ import { Button } from '../../actions/Button/Button.tsx';
 import cl from './DropdownMenu.module.scss';
 
 
-export { cl as DropdownMenuClassNames };
+/*
+References:
+- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role
+*/
 
+export { cl as DropdownMenuClassNames };
 
 export type OptionKey = string;
 export type OptionDef = { optionKey: OptionKey, label: string };
@@ -56,7 +59,7 @@ export const Action = (props: ActionProps) => {
   const { itemKey, label, icon, onActivate, ...propsRest } = props;
   
   const context = useDropdownMenuContext();
-  const { optionProps, selectedOption, selectOption } = context;
+  const { optionProps, selectedOption } = context;
   
   const option: OptionDef = { optionKey: itemKey, label };
   const isSelected = selectedOption === itemKey;
@@ -64,7 +67,10 @@ export const Action = (props: ActionProps) => {
   return (
     <li aria-selected={isSelected}>
       <Button unstyled
+        // biome-ignore lint/a11y/useSemanticElements: Cannot (yet) use `<option>` for this.
         role="option"
+        //tabIndex={-1} // Only the `role="listbox"` should be focusable, use keyboard arrows to select the option
+        data-option-key={itemKey}
         {...propsRest}
         {...optionProps?.({
           option,
@@ -73,7 +79,6 @@ export const Action = (props: ActionProps) => {
         // FIXME: merge these props with `optionProps()`
         className={cx(
           cl['bk-dropdown-menu__item'],
-          cl['bk-dropdown-menu__item--action'],
           propsRest.className,
         )}
         onPress={() => { onActivate(context); }}
@@ -107,9 +112,13 @@ export const Option = (props: OptionProps) => {
   const isSelected = selectedOption === optionKey;
   
   return (
-    <li aria-selected={isSelected}>
+    <li role="presentation">
       <Button unstyled
+        // biome-ignore lint/a11y/useSemanticElements: Cannot (yet) use `<option>` for this.
         role="option"
+        //tabIndex={-1} // Only the `role="listbox"` should be focusable, use keyboard arrows to select the option
+        data-option-key={optionKey}
+        aria-selected={isSelected}
         {...propsRest}
         {...optionProps?.({
           option,
@@ -118,7 +127,6 @@ export const Option = (props: OptionProps) => {
         // FIXME: merge these props with `optionProps()`
         className={cx(
           cl['bk-dropdown-menu__item'],
-          cl['bk-dropdown-menu__item--option'],
           propsRest.className,
         )}
         onPress={() => { selectOption(option); }}
@@ -130,27 +138,34 @@ export const Option = (props: OptionProps) => {
   );
 };
 
-export type DropdownMenuProps = React.PropsWithChildren<ComponentProps<'ul'> & {
+export type DropdownMenuProps = ComponentProps<'ul'> & {
   /** Whether this component should be unstyled. */
   unstyled?: undefined | boolean,
-}>;
+  
+  /** An accessible name for this dropdown menu. Required. */
+  label: string,
+};
 /**
  * Dropdown menu with a list of selectable options.
  */
 export const DropdownMenu = Object.assign(
   (props: DropdownMenuProps) => {
-    const { children, unstyled = false, ...propsRest } = props;
+    const { children, unstyled = false, label, ...propsRest } = props;
     
-    const scrollerProps = useScroller();
-    
+    // FIXME: need to implement keyboard arrow (up/down) navigation through items, as per:
+    // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role
     return (
       <ul
-        {...scrollerProps}
+        // biome-ignore lint/a11y/noNoninteractiveElementToInteractiveRole: Explicitly using `<ul>` as interactive.
+        // biome-ignore lint/a11y/useSemanticElements: Cannot (yet) use `<select>` for this purpose.
+        role="listbox"
+        aria-label={label}
+        tabIndex={0}
         {...propsRest}
+        //onKeyDown={handleKeyInput} // FIXME
         className={cx(
           'bk',
           { [cl['bk-dropdown-menu']]: !unstyled },
-          scrollerProps.className,
           propsRest.className,
         )}
       >

--- a/src/components/overlays/DropdownMenu/DropdownMenuProvider.tsx
+++ b/src/components/overlays/DropdownMenu/DropdownMenuProvider.tsx
@@ -17,7 +17,10 @@ export type AnchorRenderArgs = {
   open: boolean,
   state: DropdownMenuContext,
 };
-export type DropdownMenuProviderProps = Omit<ComponentProps<typeof DropdownMenu>, 'children'> & {
+export type DropdownMenuProviderProps = Omit<ComponentProps<typeof DropdownMenu>, 'children' | 'label'> & {
+  /** An accessible name for this dropdown menu. Required */
+  label: string,
+  
   /**
   * The content to render, which should contain the anchor. This should be a render prop which takes props to
   * apply on the anchor element. Alternatively, a single element can be provided to which the props are applied.
@@ -41,7 +44,15 @@ export type DropdownMenuProviderProps = Omit<ComponentProps<typeof DropdownMenu>
  */
 export const DropdownMenuProvider = Object.assign(
   (props: DropdownMenuProviderProps) => {
-    const { children, unstyled = false, items, placement = 'bottom', enablePreciseTracking, ...propsRest } = props;
+    const {
+      label,
+      children,
+      unstyled = false,
+      items,
+      placement = 'bottom',
+      enablePreciseTracking,
+      ...propsRest
+    } = props;
     
     const selectedRef = React.useRef<React.ComponentRef<typeof Option>>(null);
     const [selected, setSelected] = React.useState<null | OptionDef>(null);
@@ -121,6 +132,7 @@ export const DropdownMenuProvider = Object.assign(
         {renderAnchor()}
         
         <DropdownMenu
+          label={label}
           {...getFloatingProps({
             popover: 'manual',
             style: floatingStyles,

--- a/src/components/overlays/DropdownMenu/DropdownMenuProvider.tsx
+++ b/src/components/overlays/DropdownMenu/DropdownMenuProvider.tsx
@@ -14,6 +14,7 @@ import { DropdownMenuContext, type OptionDef, Option, Action, DropdownMenu } fro
 
 export type AnchorRenderArgs = {
   props: (userProps?: undefined | React.HTMLProps<Element>) => Record<string, unknown>,
+  open: boolean,
   state: DropdownMenuContext,
 };
 export type DropdownMenuProviderProps = Omit<ComponentProps<typeof DropdownMenu>, 'children'> & {
@@ -54,6 +55,7 @@ export const DropdownMenuProvider = Object.assign(
       getReferenceProps,
       getFloatingProps,
       getItemProps,
+      isOpen,
       setIsOpen,
     } = useFloatingElement({
       placement: placement,
@@ -98,7 +100,7 @@ export const DropdownMenuProvider = Object.assign(
       };
       
       if (typeof children === 'function') {
-        return children({ props: anchorProps, state: context });
+        return children({ props: anchorProps, open: isOpen, state: context });
       }
       
       // If a render prop is not used, try to attach it to the element directly.

--- a/src/components/overlays/ToastProvider/ToastProvider.tsx
+++ b/src/components/overlays/ToastProvider/ToastProvider.tsx
@@ -190,10 +190,9 @@ export const Toaster = (props: ToasterProps) => {
             onClose={() => {
               toastStore.dismissToast(toastId);
             }}
-            onClick={event => {
-              event.stopPropagation();
-              toastStore.dismissToast(toastId);
-            }}
+            // Handle dismiss signals (e.g. clicking or tapping on the toast)
+            onClick={event => { event.stopPropagation(); toastStore.dismissToast(toastId); }}
+            // Handle interest signals (e.g. hovering over the toast)
             onMouseEnter={event => { event.stopPropagation(); toastStore.pauseAutoClose(toastId); }}
             onTouchStart={event => { event.stopPropagation(); toastStore.pauseAutoClose(toastId); }}
             onMouseLeave={event => { event.stopPropagation(); toastStore.resumeAutoClose(toastId); }}

--- a/src/components/overlays/Tooltip/Tooltip.stories.tsx
+++ b/src/components/overlays/Tooltip/Tooltip.stories.tsx
@@ -2,14 +2,15 @@
 |* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of
 |* the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import type { Meta, StoryObj } from '@storybook/react';
-
-import { classNames as cx } from '../../../util/componentUtil.ts';
 import * as React from 'react';
 
+import type { Meta, StoryObj } from '@storybook/react';
+import { DummyLink } from '../../../util/storybook/StorybookLink.tsx';
 import { OverflowTester } from '../../../util/storybook/OverflowTester.tsx';
+
 import { Button } from '../../actions/Button/Button.tsx';
-import { TooltipClassNames, Tooltip } from './Tooltip.tsx';
+
+import { Tooltip } from './Tooltip.tsx';
 
 
 type TooltipArgs = React.ComponentProps<typeof Tooltip>;
@@ -75,7 +76,7 @@ export const TooltipScroll: StoryObj<typeof Tooltip> = {
   render: () => (
     <Tooltip>
       <p>
-        Lorem ipsum dolor sit amet, <a href="/" onClick={event => { event.preventDefault(); }}>consectetur</a> adipiscing elit. Pellentesque eget sem ut neque lobortis pharetra nec vel quam. Etiam sem neque, gravida sed pharetra ut, vehicula quis lectus. Donec ac rhoncus purus. Proin ultricies augue vitae purus feugiat, in ultrices lorem aliquet. Donec eleifend ac dolor a auctor.
+        Lorem ipsum dolor sit amet, <DummyLink>consectetur</DummyLink> adipiscing elit. Pellentesque eget sem ut neque lobortis pharetra nec vel quam. Etiam sem neque, gravida sed pharetra ut, vehicula quis lectus. Donec ac rhoncus purus. Proin ultricies augue vitae purus feugiat, in ultrices lorem aliquet. Donec eleifend ac dolor a auctor.
       </p>
       <p>
         Cras ac suscipit nibh. Fusce tincidunt iaculis dapibus. Vivamus sit amet neque eu velit tincidunt semper. Donec at magna aliquam mi consectetur imperdiet. Donec pretium placerat quam, in sodales purus porta vitae. Phasellus nisl justo, luctus vel mi vel, sollicitudin.
@@ -103,7 +104,7 @@ const TooltipNativeAnchoringControlled = () => {
       
       <Tooltip ref={refTooltip} id={id} popover="manual" style={{ positionAnchor: anchorName }}>
         This is a tooltip with a lot of text that gives more information about the element.
-        It has a <a href="/" onClick={event => { event.preventDefault(); }}>link</a> you can focus.
+        It has a <DummyLink>link</DummyLink> you can focus.
       </Tooltip>
       <Button popoverTarget={id} variant="primary" label="Hover over me"
         style={{ anchorName }}

--- a/src/components/tables/DataTable/pagination/Pagination.tsx
+++ b/src/components/tables/DataTable/pagination/Pagination.tsx
@@ -46,6 +46,7 @@ export const Pagination = ({ pageSizeOptions }: PaginationProps) => {
         <Button
           unstyled
           nonactive={!table.canPreviousPage}
+          aria-label="Go to first page"
           className={cx(cl['pager__nav'])}
           onPress={() => {
             table.gotoPage(0)
@@ -58,6 +59,7 @@ export const Pagination = ({ pageSizeOptions }: PaginationProps) => {
           <Button
             unstyled
             nonactive={!table.canPreviousPage}
+            aria-label="Go to previous page"
             className={cx(cl['pager__nav'])}
             onPress={() => {
               table.previousPage();
@@ -70,6 +72,7 @@ export const Pagination = ({ pageSizeOptions }: PaginationProps) => {
           <Input
             type="number"
             className={cx(cl['pagination__page-input'])}
+            aria-label={`Current page: ${pageIndexIndicator}`}
             value={pageIndexIndicator}
             max={table.pageCount}
             onChange={(event) => setPageIndexIndicator(Number.parseInt(event.target.value))}
@@ -86,6 +89,7 @@ export const Pagination = ({ pageSizeOptions }: PaginationProps) => {
           <Button
             unstyled
             nonactive={!table.canNextPage}
+            aria-label="Go to next page"
             className={cx(cl['pager__nav'])}
             onPress={() => {
               table.nextPage();
@@ -98,6 +102,7 @@ export const Pagination = ({ pageSizeOptions }: PaginationProps) => {
         <Button
           unstyled
           nonactive={!table.canNextPage}
+          aria-label="Go to last page"
           className={cx(cl['pager__nav'])}
           onPress={() => {
             table.gotoPage(table.pageCount - 1)

--- a/src/components/tables/DataTable/pagination/PaginationSizeSelector.module.scss
+++ b/src/components/tables/DataTable/pagination/PaginationSizeSelector.module.scss
@@ -14,9 +14,15 @@
     align-items: center;
     gap: bk.$spacing-1;
     
-    .page-size-selector__button {
+    .page-size-selector__trigger {
       color: bk.$theme-pagination-text-default;
       padding: 0;
+      
+      &.page-size-selector__trigger--open {
+        .page-size-selector__trigger__icon {
+          rotate: 0.5turn;
+        }
+      }
     }
     
     .page-size-selector__dropdown {

--- a/src/components/tables/DataTable/pagination/PaginationSizeSelector.tsx
+++ b/src/components/tables/DataTable/pagination/PaginationSizeSelector.tsx
@@ -30,6 +30,7 @@ export const PaginationSizeSelector = (props: PaginationSizeSelectorProps) => {
       {pageSizeLabel}:
       
       <DropdownMenuProvider
+        label="Page size selector"
         className={cx(cl['page-size-selector__dropdown'])}
         items={pageSizeOptions.map((pageSize) => (
           <DropdownMenuProvider.Action

--- a/src/components/tables/DataTable/pagination/PaginationSizeSelector.tsx
+++ b/src/components/tables/DataTable/pagination/PaginationSizeSelector.tsx
@@ -43,14 +43,18 @@ export const PaginationSizeSelector = (props: PaginationSizeSelectorProps) => {
           />
         ))}
       >
-        {({ props }) => (
+        {({ props, open }) => (
           <Button
             variant="tertiary"
             {...props()}
-            className={cx(cl['page-size-selector__button'])}
+            aria-label={`${table.state.pageSize} rows per page`}
+            className={cx(
+              cl['page-size-selector__trigger'],
+              { [cl['page-size-selector__trigger--open']]: open },
+            )}
           >
             {table.state.pageSize}
-            <Icon icon="caret-down"/>
+            <Icon icon="caret-down" className={cx(cl['page-size-selector__trigger__icon'])}/>
           </Button>
         )}
       </DropdownMenuProvider>

--- a/src/components/tables/DataTable/pagination/PaginationStream.module.scss
+++ b/src/components/tables/DataTable/pagination/PaginationStream.module.scss
@@ -30,9 +30,10 @@
         padding-right: 0;
         
         display: flex;
+        font-weight: bk.$font-weight-regular;
         
         &:global(.nonactive) {
-          opacity: 0.4;
+          opacity: 0.6;
         }
         
         &.pager__nav--first { --keep: ; }

--- a/src/components/tables/DataTable/pagination/PaginationStream.tsx
+++ b/src/components/tables/DataTable/pagination/PaginationStream.tsx
@@ -23,9 +23,10 @@ export const PaginationStreamPager = ({ pageSizeOptions }: PaginationStreamPager
   return (
     <div className={cx(cl['pagination__pager'])}>
       <Button unstyled
+        aria-label="First page"
         className={cx(cl['pager__nav'], cl['pager__nav--first'])}
-        onPress={() => { table.gotoPage(0); }}
         nonactive={!table.canPreviousPage}
+        onPress={() => { table.gotoPage(0); }}
       >
         <Icon icon="page-backward"/>
       </Button>

--- a/src/components/tables/DataTable/plugins/useRowSelectColumn.tsx
+++ b/src/components/tables/DataTable/plugins/useRowSelectColumn.tsx
@@ -19,13 +19,13 @@ export const useRowSelectColumn = <D extends object>(hooks: ReactTable.Hooks<D>)
       Header: ({ getToggleAllPageRowsSelectedProps }) => {
         const { checked, onChange } = getToggleAllPageRowsSelectedProps();
         return (
-          <Checkbox checked={checked} onChange={onChange}/>
+          <Checkbox aria-label="Select all rows" checked={checked} onChange={onChange}/>
         );
       },
       Cell: ({ row }: ReactTable.CellProps<D, null>) => {
         const { checked, onChange } = row.getToggleRowSelectedProps();
         return (
-          <Checkbox checked={checked} onChange={onChange}/>
+          <Checkbox aria-label="Select row" checked={checked} onChange={onChange}/>
         );
       },
     },

--- a/src/components/tables/DataTable/table/DataTable.tsx
+++ b/src/components/tables/DataTable/table/DataTable.tsx
@@ -107,7 +107,7 @@ export const DataTable = <D extends object>(props: DataTableProps<D>) => {
               {/*<td className="bk-table__row__select">
                 <input type="checkbox"
                   checked={row.isSelected}
-                  onClick={() => { row.toggleRowSelected(); }}
+                  onChange={() => { row.toggleRowSelected(); }}
                 />
               </td>*/}
               {row.cells.map(cell => {

--- a/src/layouts/AppLayout/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/layouts/AppLayout/Breadcrumbs/Breadcrumbs.tsx
@@ -43,6 +43,7 @@ export const Breadcrumbs = (props: BreadcrumbsProps) => {
           const isLast = index === items.length - 1;
           return (
             <li
+              // biome-ignore lint/suspicious/noArrayIndexKey: No other unique key available
               key={index}
               className={cx({
                 [cl['bk-breadcrumb-item']]: true,

--- a/src/layouts/AppLayout/Header/AccountSelector.module.scss
+++ b/src/layouts/AppLayout/Header/AccountSelector.module.scss
@@ -8,6 +8,8 @@
   .bk-account-selector {
     @include bk.component-base(bk-account-selector);
     
+    user-select: none;
+    
     // Allow the element to shrink down to just the icon
     overflow: hidden;
     flex-shrink: 4; // Shrink relatively fast (since there is no important information besides the icon)

--- a/src/layouts/AppLayout/Header/AccountSelector.tsx
+++ b/src/layouts/AppLayout/Header/AccountSelector.tsx
@@ -23,6 +23,7 @@ export const AccountSelector = (props: AccountSelectorProps) => {
   
   return (
     <DropdownMenuProvider
+      label="Account selector"
       placement="bottom-start"
       items={
         <>

--- a/src/layouts/AppLayout/Header/Header.tsx
+++ b/src/layouts/AppLayout/Header/Header.tsx
@@ -18,7 +18,9 @@ export type HeaderProps = React.PropsWithChildren<ComponentProps<'header'> & {
 export const Header = ({ children, unstyled, ...propsRest }: HeaderProps) => {
   return (
     <header
-      role="banner"
+      // Note: `<header>` has an implicit default role of "banner", if it is not inside a `<section>` element
+      // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header
+      //role="banner"
       {...propsRest}
       className={cx(
         'bk',

--- a/src/layouts/AppLayout/Header/SolutionSelector.tsx
+++ b/src/layouts/AppLayout/Header/SolutionSelector.tsx
@@ -23,6 +23,7 @@ export const SolutionSelector = (props: SolutionSelectorProps) => {
   
   return (
     <DropdownMenuProvider
+      label="Solution selector"
       placement="bottom-start"
       items={
         <>

--- a/src/layouts/AppLayout/Header/UserMenu.tsx
+++ b/src/layouts/AppLayout/Header/UserMenu.tsx
@@ -38,6 +38,7 @@ export const UserMenu = (props: UserMenuProps) => {
   
   return (
     <DropdownMenuProvider
+      label="User menu"
       placement="bottom-end"
       items={
         <>

--- a/src/typography/BodyText/BodyText.stories.tsx
+++ b/src/typography/BodyText/BodyText.stories.tsx
@@ -3,11 +3,13 @@
 |* the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react';
+
 import type { Meta, StoryObj } from '@storybook/react';
+import { DummyLink } from '../../util/storybook/StorybookLink.tsx';
 
 import { Button } from '../../components/actions/Button/Button.tsx';
-import { Panel } from '../../components/containers/Panel/Panel.tsx';
 import { SegmentedControl } from '../../components/forms/controls/SegmentedControl/SegmentedControl.tsx';
+import { Panel } from '../../components/containers/Panel/Panel.tsx';
 
 import { BodyText } from './BodyText.tsx';
 
@@ -36,7 +38,7 @@ const SampleBodyText = () => {
       <h1>Example of body text</h1>
       <h2>Example of body text</h2>
       <p>
-        Lorem ipsum dolor sit amet, <a href="/" onClick={event => { event.preventDefault(); }}>consectetur</a> adipiscing elit. Pellentesque eget sem ut neque lobortis pharetra nec vel quam. Etiam sem neque, gravida sed pharetra ut, vehicula quis lectus. Donec ac rhoncus purus. Proin ultricies augue vitae purus feugiat, in ultrices lorem aliquet. Donec eleifend ac dolor a auctor. Cras ac suscipit nibh. Fusce tincidunt iaculis dapibus. Vivamus sit amet neque eu velit tincidunt semper. Donec at magna aliquam mi consectetur imperdiet. Donec pretium placerat quam, in sodales purus porta vitae. Phasellus nisl justo, luctus vel mi vel, sollicitudin euismod neque.
+        Lorem ipsum dolor sit amet, <DummyLink>consectetur</DummyLink> adipiscing elit. Pellentesque eget sem ut neque lobortis pharetra nec vel quam. Etiam sem neque, gravida sed pharetra ut, vehicula quis lectus. Donec ac rhoncus purus. Proin ultricies augue vitae purus feugiat, in ultrices lorem aliquet. Donec eleifend ac dolor a auctor. Cras ac suscipit nibh. Fusce tincidunt iaculis dapibus. Vivamus sit amet neque eu velit tincidunt semper. Donec at magna aliquam mi consectetur imperdiet. Donec pretium placerat quam, in sodales purus porta vitae. Phasellus nisl justo, luctus vel mi vel, sollicitudin euismod neque.
       </p>
       <p>
         Duis mollis, justo vel pretium luctus, risus sem eleifend lectus, ac convallis dolor nibh id sapien. Donec vestibulum tellus non rutrum convallis. Aenean venenatis enim in egestas lobortis. Donec mollis elit in turpis imperdiet congue vel at magna. Vestibulum bibendum, ipsum quis lobortis lobortis, lorem libero mollis sapien, sed tempus lacus nibh a nunc. Vivamus sed sem eleifend, rutrum erat eget, ultricies neque. Morbi condimentum dolor vel ipsum consectetur iaculis. Donec ornare diam at orci luctus, sed placerat quam dictum. Interdum et malesuada fames ac ante ipsum primis in faucibus. Curabitur condimentum molestie augue. Ut vel nisl a augue ornare volutpat. Phasellus et enim in mi maximus ultricies. Integer dignissim ipsum mauris, id bibendum eros euismod et.

--- a/src/util/componentUtil.ts
+++ b/src/util/componentUtil.ts
@@ -4,11 +4,21 @@
 
 // Note: use the `dedupe` variant so that the consumer of a component can overwrite classes from the component using
 // `<MyComponent className={{ foo: false }}/>`
-import classNames from 'classnames/dedupe';
-import type { Argument as ClassNameArgument } from 'classnames';
+import classNamesDedupe from 'classnames/dedupe';
+import type { Argument as ClassNameArgument, ArgumentArray } from 'classnames';
 
 
-export { classNames, type ClassNameArgument };
+export type { ClassNameArgument };
+
+export const classNames = (...args: ArgumentArray): string => {
+  const className = classNamesDedupe(...args);
+  
+  if (import.meta.env.MODE === 'development' && className.split(' ').includes('undefined')) {
+    console.warn('Found `undefined` in class names list');
+  }
+  
+  return className;
+};
 
 // Version of `React.ComponentPropsWithRef` that supports `classnames` syntax for the `className` attribute. So that
 // components can take class names not just of type string, but any valid classnames `Argument`, e.g.:

--- a/src/util/storybook/StorybookLink.tsx
+++ b/src/util/storybook/StorybookLink.tsx
@@ -1,0 +1,9 @@
+/* Copyright (c) Fortanix, Inc.
+|* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of
+|* the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react';
+
+
+export const DummyLink = (props: React.ComponentProps<'a'>) =>
+  <a href="/" onClick={event => { event.preventDefault(); }} {...props}/>;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -58,6 +58,5 @@
   "exclude": [
     "node_modules",
     "**/*.spec.ts",
-    "src/components/navigations/Tabs/Tabs.stories.tsx", // FIXME: need to fix a few type errors
   ],
 }


### PR DESCRIPTION
This PR:

- Fixes most of the remaining Biome linter errors. There are currently still three Biome errors left, which will be tackled as part of this issue: https://github.com/fortanix/baklava/issues/116
- Fixes the TypeScript errors in `src/components/navigations/Tabs/Tabs.stories.tsx`, and removes it from the `exclude` list.
- Fixes some of the accessibility violations reported by axe. Though a decent number of these still remain, most of them due to color contrast violations.
- Tries to work around this [axe parallelism issue](https://github.com/dequelabs/axe-core/issues/3426).
- Fixes most of the incorrect uses of `onClick` described in #68.

After this PR, we have the following left to fix:
- 3 biome errors
- 92 (out of 273) failing accessibility tests

Resolves #29.