### PR TITLE
`SegmentedControl` improvements: keyboard interactions, composition, icon

### DIFF
--- a/src/components/actions/Button/Button.module.scss
+++ b/src/components/actions/Button/Button.module.scss
@@ -176,10 +176,16 @@
         }
       }
     }
+    &:active {
+      filter: brightness(90%);
+    }
     
     @media (prefers-reduced-motion: no-preference) {
-      transition: none 150ms ease-in-out;
-      transition-property: border, background, color;
+      transition:
+        border 150ms ease-in-out
+        background-color 150ms ease-in-out
+        color 150ms ease-in-out,
+        filter 100ms ease-out;
     }
     
     /* & > :global(.icon) { font-size: 1.2rem; } */

--- a/src/components/actions/Button/Button.module.scss
+++ b/src/components/actions/Button/Button.module.scss
@@ -176,16 +176,16 @@
         }
       }
     }
-    &:active {
-      filter: brightness(90%);
+    &:not(:disabled, .bk-button--disabled, .bk-button--nonactive):active {
+      scale: 0.98;
     }
     
     @media (prefers-reduced-motion: no-preference) {
       transition:
-        border 150ms ease-in-out
-        background-color 150ms ease-in-out
+        border 150ms ease-in-out,
+        background-color 150ms ease-in-out,
         color 150ms ease-in-out,
-        filter 100ms ease-out;
+        scale 100ms ease-in;
     }
     
     /* & > :global(.icon) { font-size: 1.2rem; } */

--- a/src/components/actions/Button/Button.module.scss
+++ b/src/components/actions/Button/Button.module.scss
@@ -31,7 +31,7 @@
     display: inline-flex;
     flex-flow: row wrap;
     align-items: center;
-    gap: 0.3ch;
+    gap: bk.$spacing-1;
     
     @include bk.font(bk.$font-family-display, bk.$font-weight-semibold);
     text-transform: uppercase;
@@ -188,9 +188,10 @@
         scale 100ms ease-in;
     }
     
-    /* & > :global(.icon) { font-size: 1.2rem; } */
+    & > :global(.icon) { font-size: 1em; }
     
-    /* https://css-tricks.com/css-cascade-layers/#aa-reverting-important-layers */
-    /* &:is(:global(.unstyled), #specificity#hack) { all: revert-layer; } */
+    // Experiment: implementing `unstyled` using `revert-layer` rather than by removing the class names
+    // https://css-tricks.com/css-cascade-layers/#aa-reverting-important-layers
+    // &:is(:global(.unstyled), #specificity#hack) { all: revert-layer; }
   }
 }

--- a/src/components/actions/Button/Button.stories.tsx
+++ b/src/components/actions/Button/Button.stories.tsx
@@ -177,6 +177,14 @@ export const VariantCard: Story = {
   ),
 };
 
+export const ButtonWithIcon: Story = {
+  ...PrimaryStory,
+  args: {
+    label: 'I have an icon',
+    icon: 'check',
+  },
+};
+
 export const AsyncButton: Story = {
   ...PrimaryStory,
   args: {

--- a/src/components/actions/Button/Button.tsx
+++ b/src/components/actions/Button/Button.tsx
@@ -7,6 +7,7 @@ import { timeout } from '../../../util/time.ts';
 import { classNames as cx, type ComponentProps } from '../../../util/componentUtil.ts';
 import * as React from 'react';
 
+import { type IconName, Icon } from '../../graphics/Icon/Icon.tsx';
 import { Spinner } from '../../graphics/Spinner/Spinner.tsx';
 
 import cl from './Button.module.scss';
@@ -28,6 +29,9 @@ export type ButtonProps = React.PropsWithChildren<Omit<ComponentProps<'button'>,
    * the button content is desired, use `children` instead, this overrides the `label`.
    */
   label?: undefined | string,
+  
+  /** An icon to show before the label. Optional. */
+  icon?: undefined | IconName,
   
   /** The kind of button, from higher prominance to lower. */
   kind?: undefined | 'primary' | 'secondary' | 'tertiary',
@@ -63,6 +67,7 @@ export const Button = (props: ButtonProps) => {
     unstyled = false,
     trimmed = false,
     label,
+    icon,
     kind = 'tertiary',
     variant = 'normal',
     disabled = false,
@@ -117,6 +122,7 @@ export const Button = (props: ButtonProps) => {
     return (
       <>
         {isPending && <Spinner className="icon" inline/>}
+        {icon && <Icon className="icon" icon={icon}/>}
         {label}
       </>
     );

--- a/src/components/actions/IconButton/IconButton.module.scss
+++ b/src/components/actions/IconButton/IconButton.module.scss
@@ -14,5 +14,13 @@
     &.inline {
       display: inline-flex;
     }
+    
+    &:not(:disabled):active {
+      scale: 0.95;
+    }
+    
+    @media (prefers-reduced-motion: no-preference) {
+      transition: scale 100ms ease-in;
+    }
   }
 }

--- a/src/components/actions/Link/Link.stories.tsx
+++ b/src/components/actions/Link/Link.stories.tsx
@@ -25,6 +25,7 @@ export default {
   args: {
     unstyled: false,
     label: 'Link',
+    onClick: event => { event.preventDefault(); },
   },
   render: (args) => <Link {...args}/>,
 } satisfies Meta<LinkArgs>;
@@ -48,7 +49,7 @@ export const Scroll: Story = {
     <>
       <DummyLink id="anchor">Anchor</DummyLink>
       <OverflowTester openDefault/>
-      <Link {...args} href="#anchor"/>
+      <Link {...args} href="#anchor" onClick={undefined}/>
       <OverflowTester openDefault/>
     </>
   ),

--- a/src/components/actions/LinkAsButton/LinkAsButton.stories.tsx
+++ b/src/components/actions/LinkAsButton/LinkAsButton.stories.tsx
@@ -7,7 +7,6 @@ import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { LinkAsButton } from './LinkAsButton.tsx';
-import { OverflowTester } from '../../../util/storybook/OverflowTester.tsx';
 
 
 type LinkAsButtonArgs = React.ComponentProps<typeof LinkAsButton>;
@@ -26,6 +25,7 @@ export default {
     label: 'Link',
     href: 'https://fortanix.com',
     target: '_blank',
+    onClick: event => { event.preventDefault(); },
   },
   render: (args) => <LinkAsButton {...args}/>,
 } satisfies Meta<LinkAsButtonArgs>;
@@ -66,5 +66,6 @@ export const Download: Story = {
     download: 'my_file.txt',
     label: 'Download',
     href: `data:text/plain,Lorem ipsum`,
+    onClick: undefined,
   },
 };

--- a/src/components/containers/Banner/Banner.stories.tsx
+++ b/src/components/containers/Banner/Banner.stories.tsx
@@ -163,7 +163,7 @@ export const BannerWithThemedContent: Story = {
         </p>
         <div style={{ display: 'flex', gap: '2ch', marginTop: '1lh' }}>
           <Button nonactive kind="primary" onPress={() => { notify.info('Clicked'); }}>Button</Button>
-          <SegmentedControl defaultButtonKey="test-1" aria-label="Test segmented control">
+          <SegmentedControl size="small" defaultButtonKey="test-1" aria-label="Test segmented control">
             <SegmentedControl.Button buttonKey="test-1" label="Test 1"/>
             <SegmentedControl.Button buttonKey="test-2" label="Test 2"/>
             <SegmentedControl.Button buttonKey="test-3" label="Test 3"/>

--- a/src/components/containers/Banner/Banner.stories.tsx
+++ b/src/components/containers/Banner/Banner.stories.tsx
@@ -163,10 +163,11 @@ export const BannerWithThemedContent: Story = {
         </p>
         <div style={{ display: 'flex', gap: '2ch', marginTop: '1lh' }}>
           <Button nonactive kind="primary" onPress={() => { notify.info('Clicked'); }}>Button</Button>
-          <SegmentedControl
-            options={['Test 1', 'Test 2']}
-            defaultValue="Test 1"
-          />
+          <SegmentedControl defaultButtonKey="test-1" aria-label="Test segmented control">
+            <SegmentedControl.Button buttonKey="test-1" label="Test 1"/>
+            <SegmentedControl.Button buttonKey="test-2" label="Test 2"/>
+            <SegmentedControl.Button buttonKey="test-3" label="Test 3"/>
+          </SegmentedControl>
         </div>
       </article>
     ),

--- a/src/components/forms/controls/SegmentedControl/SegmentedControl.module.scss
+++ b/src/components/forms/controls/SegmentedControl/SegmentedControl.module.scss
@@ -10,7 +10,7 @@
     
     display: flex;
     
-    .bk-segmented-control__toggle {
+    .bk-segmented-control__button {
       --bk-segmented-control-toggle-background-color: #{bk.$theme-segmented-control-background-default};
       --bk-segmented-control-toggle-border-color: #{bk.$theme-segmented-control-border-unselected};
       --bk-segmented-control-toggle-text-color: #{bk.$theme-segmented-control-text-unselected};
@@ -29,14 +29,14 @@
     
     .bk-segmented-control__item {
       &:first-child {
-        .bk-segmented-control__toggle {
+        .bk-segmented-control__button {
           border-inline-start: 1px solid var(--bk-segmented-control-toggle-border-color);
           border-radius: 2px 0 0 2px;
         }
       }
       
       &:last-child {
-        .bk-segmented-control__toggle {
+        .bk-segmented-control__button {
           border-radius: 0 2px 2px 0;
         }
       }
@@ -44,7 +44,7 @@
     
     /* States */
     &:not(.bk-segmented-control--disabled) {
-      .bk-segmented-control__toggle {
+      .bk-segmented-control__button:not(:disabled) {
         &[aria-checked="true"] {
           --bk-segmented-control-toggle-background-color: #{bk.$theme-segmented-control-background-selected};
           //--bk-segmented-control-toggle-border-color: #{bk.$theme-segmented-control-border-selected};
@@ -65,16 +65,14 @@
       }
     }
     
-    &.bk-segmented-control--disabled {
-      .bk-segmented-control__toggle {
-        --bk-segmented-control-toggle-background-color: #{bk.$theme-segmented-control-background-disabled-2};
-        --bk-segmented-control-toggle-border-color: #{bk.$theme-segmented-control-border-disabled};
-        --bk-segmented-control-toggle-text-color: #{bk.$theme-segmented-control-text-unselected-2};
-        cursor: not-allowed;
-        
-        &[aria-checked="true"] {
-          --bk-segmented-control-toggle-background-color: #{bk.$theme-segmented-control-background-disabled};
-        }
+    :is(&.bk-segmented-control--disabled .bk-segmented-control__button, .bk-segmented-control__button:disabled) {
+      --bk-segmented-control-toggle-background-color: #{bk.$theme-segmented-control-background-disabled-2};
+      --bk-segmented-control-toggle-border-color: #{bk.$theme-segmented-control-border-disabled};
+      --bk-segmented-control-toggle-text-color: #{bk.$theme-segmented-control-text-unselected-2};
+      cursor: not-allowed;
+      
+      &[aria-checked="true"] {
+        --bk-segmented-control-toggle-background-color: #{bk.$theme-segmented-control-background-disabled};
       }
     }
   }

--- a/src/components/forms/controls/SegmentedControl/SegmentedControl.module.scss
+++ b/src/components/forms/controls/SegmentedControl/SegmentedControl.module.scss
@@ -8,80 +8,103 @@
   .bk-segmented-control {
     @include bk.component-base(bk-segmented-control);
     
+    --bk-segmented-control-background-color: #{bk.$theme-segmented-control-background-default};
+    --bk-segmented-control-border-color: #{bk.$theme-segmented-control-border-unselected};
+    --bk-segmented-control-text-color: #{bk.$theme-segmented-control-text-unselected};
+    
+    //overflow: hidden; // Note: cannot hide overflow, would truncate focus outlines
+    
+    border: bk.rem-from-px(1) solid var(--bk-segmented-control-border-color);
+    border-radius: bk.$radius-1;
+    background: var(--bk-segmented-control-border-color);
+    
     display: flex;
     flex-direction: row;
+    gap: bk.rem-from-px(1);
+    
+    // Set this to allow wrapping:
+    //flex-wrap: wrap;
+    // Note: may want to implement https://heydonworks.com/article/the-flexbox-holy-albatross-reincarnated
     
     .bk-segmented-control__button {
-      --bk-segmented-control-toggle-background-color: #{bk.$theme-segmented-control-background-default};
-      --bk-segmented-control-toggle-border-color: #{bk.$theme-segmented-control-border-unselected};
-      --bk-segmented-control-toggle-text-color: #{bk.$theme-segmented-control-text-unselected};
+      // For the inner radius, subtract the border width
+      --inner-radius: #{calc(bk.$radius-1 - bk.rem-from-px(1))};
+      
+      flex-grow: 1; // Fill full width in case `flex-wrap` is enabled
       
       user-select: none;
       
       padding: bk.$spacing-1 bk.$spacing-3;
-      background-color: var(--bk-segmented-control-toggle-background-color);
-      border: bk.rem-from-px(1) solid var(--bk-segmented-control-toggle-border-color);
-      border-inline-start: 0;
+      background-color: var(--bk-segmented-control-background-color);
       
-      &:first-child {
-        border-inline-start: bk.rem-from-px(1) solid var(--bk-segmented-control-toggle-border-color);
-        border-radius: bk.$radius-1 0 0 bk.$radius-1;
-      }
-      &:last-child {
-        border-radius: 0 bk.$radius-1 bk.$radius-1 0;
-      }
-      
-      color: var(--bk-segmented-control-toggle-text-color);
-      font-weight: bk.$font-weight-semibold;
-      font-size: bk.$font-size-xs;
+      color: var(--bk-segmented-control-text-color);
+      @include bk.font($family: bk.$font-family-body, $weight: bk.$font-weight-semibold, $size: bk.$font-size-xs);
       text-transform: uppercase;
       
+      &:first-of-type {
+        border-start-start-radius: var(--inner-radius);
+        border-end-start-radius: var(--inner-radius);
+      }
+      &:last-of-type {
+        border-start-end-radius: var(--inner-radius);
+        border-end-end-radius: var(--inner-radius);
+      }
+      
+      display: flex;
+      flex-direction: row;
+      column-gap: bk.$spacing-1;
+      justify-items: center;
+      min-height: 1.5lh; // For case where there are icons only
+      
+      > :global(.icon) {
+        font-size: 1em;
+      }
+      
+      // Selected button
+      &[aria-checked="true"] {
+        --bk-segmented-control-background-color: #{bk.$theme-segmented-control-background-selected};
+        --bk-segmented-control-text-color: #{bk.$theme-segmented-control-text-default};
+      }
+      
+      // State: hover (only for non-selected buttons)
+      &:is(:hover, :global(.pseudo-hover)):not([aria-checked="true"]) {
+        --bk-segmented-control-background-color: #{bk.$theme-segmented-control-background-hover};
+      }
+      
+      @include bk.focus-outset;
+      &:is(:focus-visible, :global(.pseudo-focus-visible)) {
+        isolation: isolate; // Have the focused toggle render over the other toggles so that the focus is fully shown
+        border-radius: bk.$radius-1;
+      }
+      
+      // State: active
       &:active {
         filter: brightness(90%);
       }
-      
       @media (prefers-reduced-motion: no-preference) {
         transition: filter 100ms ease-out;
       }
-    }
-    
-    /* States */
-    &:not(.bk-segmented-control--disabled) {
-      .bk-segmented-control__button:not(:disabled) {
-        &[aria-checked="true"] {
-          --bk-segmented-control-toggle-background-color: #{bk.$theme-segmented-control-background-selected};
-          //--bk-segmented-control-toggle-border-color: #{bk.$theme-segmented-control-border-selected};
-          --bk-segmented-control-toggle-text-color: #{bk.$theme-segmented-control-text-default};
-        }
-        
-        &:not(:is([aria-checked="true"])):is(:hover, :global(.pseudo-hover)) {
-          --bk-segmented-control-toggle-background-color: #{bk.$theme-segmented-control-background-hover};
-        }
-        
-        --bk-focus-outline-color: #{bk.$theme-segmented-control-border-focus};
-        @include bk.focus-outset;
-        &:is(:focus-visible, :global(.pseudo-focus-visible)) {
-          position: relative; // Have the focused toggle render over the other toggles so that the focus is fully shown
-          border-inline-start: bk.rem-from-px(1) solid var(--bk-segmented-control-toggle-border-color);
-          border-radius: bk.$radius-2;
-          
-          &:not(:first-child) {
-            // Workaround for layout shifting on focus
-            margin-inline-start: bk.rem-from-px(-1);
-          }
-        }
-      }
-    }
-    
-    :is(&.bk-segmented-control--disabled .bk-segmented-control__button, .bk-segmented-control__button:disabled) {
-      --bk-segmented-control-toggle-background-color: #{bk.$theme-segmented-control-background-disabled-2};
-      --bk-segmented-control-toggle-border-color: #{bk.$theme-segmented-control-border-disabled};
-      --bk-segmented-control-toggle-text-color: #{bk.$theme-segmented-control-text-unselected-2};
-      cursor: not-allowed;
       
-      &[aria-checked="true"] {
-        --bk-segmented-control-toggle-background-color: #{bk.$theme-segmented-control-background-disabled};
+      // State: disabled (single button)
+      &.bk-segmented-control__button:disabled {
+        --bk-segmented-control-background-color: #{bk.$theme-segmented-control-background-disabled-2};
+        --bk-segmented-control-text-color: #{bk.$theme-segmented-control-text-unselected-2};
+        
+        cursor: not-allowed;
+        
+        &[aria-checked="true"] {
+          --bk-segmented-control-background-color: #{bk.$theme-segmented-control-background-disabled};
+        }
       }
+    }
+    
+    // State: disabled (entire control)
+    &.bk-segmented-control--disabled {
+      --bk-segmented-control-background-color: #{bk.$theme-segmented-control-background-disabled-2};
+      --bk-segmented-control-border-color: #{bk.$theme-segmented-control-border-disabled};
+      --bk-segmented-control-text-color: #{bk.$theme-segmented-control-text-unselected-2};
+      
+      cursor: not-allowed;
     }
   }
 }

--- a/src/components/forms/controls/SegmentedControl/SegmentedControl.module.scss
+++ b/src/components/forms/controls/SegmentedControl/SegmentedControl.module.scss
@@ -22,6 +22,14 @@
       border: bk.rem-from-px(1) solid var(--bk-segmented-control-toggle-border-color);
       border-inline-start: 0;
       
+      &:first-child {
+        border-inline-start: bk.rem-from-px(1) solid var(--bk-segmented-control-toggle-border-color);
+        border-radius: bk.$radius-1 0 0 bk.$radius-1;
+      }
+      &:last-child {
+        border-radius: 0 bk.$radius-1 bk.$radius-1 0;
+      }
+      
       color: var(--bk-segmented-control-toggle-text-color);
       font-weight: bk.$font-weight-semibold;
       text-transform: uppercase;
@@ -32,21 +40,6 @@
       
       @media (prefers-reduced-motion: no-preference) {
         transition: filter 100ms ease-out;
-      }
-    }
-    
-    .bk-segmented-control__item {
-      &:first-child {
-        .bk-segmented-control__button {
-          border-inline-start: bk.rem-from-px(1) solid var(--bk-segmented-control-toggle-border-color);
-          border-radius: bk.$radius-1 0 0 bk.$radius-1;
-        }
-      }
-      
-      &:last-child {
-        .bk-segmented-control__button {
-          border-radius: 0 bk.$radius-1 bk.$radius-1 0;
-        }
       }
     }
     
@@ -67,6 +60,7 @@
         @include bk.focus-outset;
         &:is(:focus-visible, :global(.pseudo-focus-visible)) {
           position: relative; // Have the focused toggle render over the other toggles so that the focus is fully shown
+          margin-inline-start: bk.rem-from-px(-1);
           border-inline-start: bk.rem-from-px(1) solid var(--bk-segmented-control-toggle-border-color);
           border-radius: bk.$radius-2;
         }

--- a/src/components/forms/controls/SegmentedControl/SegmentedControl.module.scss
+++ b/src/components/forms/controls/SegmentedControl/SegmentedControl.module.scss
@@ -19,25 +19,33 @@
       
       padding: bk.$spacing-1 bk.$spacing-3;
       background-color: var(--bk-segmented-control-toggle-background-color);
-      border: 1px solid var(--bk-segmented-control-toggle-border-color);
+      border: bk.rem-from-px(1) solid var(--bk-segmented-control-toggle-border-color);
       border-inline-start: 0;
       
       color: var(--bk-segmented-control-toggle-text-color);
       font-weight: bk.$font-weight-semibold;
       text-transform: uppercase;
+      
+      &:active {
+        filter: brightness(90%);
+      }
+      
+      @media (prefers-reduced-motion: no-preference) {
+        transition: filter 100ms ease-out;
+      }
     }
     
     .bk-segmented-control__item {
       &:first-child {
         .bk-segmented-control__button {
-          border-inline-start: 1px solid var(--bk-segmented-control-toggle-border-color);
-          border-radius: 2px 0 0 2px;
+          border-inline-start: bk.rem-from-px(1) solid var(--bk-segmented-control-toggle-border-color);
+          border-radius: bk.$radius-1 0 0 bk.$radius-1;
         }
       }
       
       &:last-child {
         .bk-segmented-control__button {
-          border-radius: 0 2px 2px 0;
+          border-radius: 0 bk.$radius-1 bk.$radius-1 0;
         }
       }
     }
@@ -59,7 +67,7 @@
         @include bk.focus-outset;
         &:is(:focus-visible, :global(.pseudo-focus-visible)) {
           position: relative; // Have the focused toggle render over the other toggles so that the focus is fully shown
-          border-inline-start: 1px solid var(--bk-segmented-control-toggle-border-color);
+          border-inline-start: bk.rem-from-px(1) solid var(--bk-segmented-control-toggle-border-color);
           border-radius: bk.$radius-2;
         }
       }

--- a/src/components/forms/controls/SegmentedControl/SegmentedControl.module.scss
+++ b/src/components/forms/controls/SegmentedControl/SegmentedControl.module.scss
@@ -9,6 +9,7 @@
     @include bk.component-base(bk-segmented-control);
     
     display: flex;
+    flex-direction: row;
     
     .bk-segmented-control__button {
       --bk-segmented-control-toggle-background-color: #{bk.$theme-segmented-control-background-default};
@@ -32,6 +33,7 @@
       
       color: var(--bk-segmented-control-toggle-text-color);
       font-weight: bk.$font-weight-semibold;
+      font-size: bk.$font-size-xs;
       text-transform: uppercase;
       
       &:active {
@@ -60,9 +62,13 @@
         @include bk.focus-outset;
         &:is(:focus-visible, :global(.pseudo-focus-visible)) {
           position: relative; // Have the focused toggle render over the other toggles so that the focus is fully shown
-          margin-inline-start: bk.rem-from-px(-1);
           border-inline-start: bk.rem-from-px(1) solid var(--bk-segmented-control-toggle-border-color);
           border-radius: bk.$radius-2;
+          
+          &:not(:first-child) {
+            // Workaround for layout shifting on focus
+            margin-inline-start: bk.rem-from-px(-1);
+          }
         }
       }
     }

--- a/src/components/forms/controls/SegmentedControl/SegmentedControl.stories.tsx
+++ b/src/components/forms/controls/SegmentedControl/SegmentedControl.stories.tsx
@@ -21,15 +21,16 @@ export default {
   argTypes: {
   },
   args: {
-    options: ['Test1', 'Test2', 'Test3'],
+    children: (
+      <>
+        <SegmentedControl.Button buttonKey="red" label="Red"/>
+        <SegmentedControl.Button buttonKey="green" label="Green"/>
+        <SegmentedControl.Button buttonKey="blue" label="Blue"/>
+      </>
+    ),
   },
   render: (args) => <SegmentedControl {...args}/>,
 } satisfies Meta<SegmentedControlArgs>;
-
-const BaseStory: Story = {
-  args: {},
-  render: (args) => <SegmentedControl {...args}/>,
-};
 
 const baseOptions = [
   {
@@ -46,10 +47,36 @@ const baseOptions = [
   },
 ];
 
-export const Standard: Story = {
-  ...BaseStory,
-  name: 'SegmentedControl [standard]',
+export const SegmentedControlStandard: Story = {};
+
+export const SegmentedControlDisabled: Story = {
+  args: {
+    disabled: true,
+  },
 };
+
+export const SegmentedControlDisabledOne: Story = {
+  args: {
+    children: (
+      <>
+        <SegmentedControl.Button buttonKey="red" label="Red"/>
+        <SegmentedControl.Button buttonKey="green" label="Green" disabled/>
+        <SegmentedControl.Button buttonKey="blue" label="Blue"/>
+      </>
+    ),
+  },
+};
+
+
+
+
+
+
+const BaseStory: Story = {
+  args: {},
+  render: (args) => <SegmentedControl {...args}/>,
+};
+
 
 export const StandardHover: Story = {
   ...BaseStory,

--- a/src/components/forms/controls/SegmentedControl/SegmentedControl.stories.tsx
+++ b/src/components/forms/controls/SegmentedControl/SegmentedControl.stories.tsx
@@ -34,20 +34,6 @@ export default {
   render: (args) => <SegmentedControl {...args}/>,
 } satisfies Meta<SegmentedControlArgs>;
 
-const baseOptions = [
-  {
-    value: 'test1',
-    label: 'Test1',
-  },
-  {
-    value: 'test2',
-    label: 'Test2',
-  },
-  {
-    value: 'test3',
-    label: 'Test3',
-  },
-];
 
 export const SegmentedControlStandard: Story = {};
 

--- a/src/components/forms/controls/SegmentedControl/SegmentedControl.stories.tsx
+++ b/src/components/forms/controls/SegmentedControl/SegmentedControl.stories.tsx
@@ -37,12 +37,36 @@ export default {
 
 export const SegmentedControlStandard: Story = {};
 
+export const SegmentedControlWithIcon: Story = {
+  args: {
+    defaultButtonKey: 'edit',
+    children: (
+      <>
+        <SegmentedControl.Button buttonKey="edit" icon="edit" label="Edit"/>
+        <SegmentedControl.Button buttonKey="delete" icon="delete" label="Delete"/>
+      </>
+    ),
+  },
+};
+
+export const SegmentedControlWithIconOnly: Story = {
+  args: {
+    defaultButtonKey: 'edit',
+    children: (
+      <>
+        <SegmentedControl.Button buttonKey="edit" icon="edit"/>
+        <SegmentedControl.Button buttonKey="delete" icon="delete"/>
+      </>
+    ),
+  },
+};
+
 export const SegmentedControlHover: Story = {
   args: {
     children: (
       <>
-        <SegmentedControl.Button buttonKey="red" label="Red" className="pseudo-hover"/>
-        <SegmentedControl.Button buttonKey="green" label="Green"/>
+        <SegmentedControl.Button buttonKey="red" label="Red"/>
+        <SegmentedControl.Button buttonKey="green" label="Green" className="pseudo-hover"/>
         <SegmentedControl.Button buttonKey="blue" label="Blue"/>
       </>
     ),

--- a/src/components/forms/controls/SegmentedControl/SegmentedControl.stories.tsx
+++ b/src/components/forms/controls/SegmentedControl/SegmentedControl.stories.tsx
@@ -21,6 +21,7 @@ export default {
   argTypes: {
   },
   args: {
+    'aria-label': 'Choose a color',
     defaultButtonKey: 'red',
     children: (
       <>
@@ -50,6 +51,30 @@ const baseOptions = [
 
 export const SegmentedControlStandard: Story = {};
 
+export const SegmentedControlHover: Story = {
+  args: {
+    children: (
+      <>
+        <SegmentedControl.Button buttonKey="red" label="Red" buttonClassName="pseudo-hover"/>
+        <SegmentedControl.Button buttonKey="green" label="Green"/>
+        <SegmentedControl.Button buttonKey="blue" label="Blue"/>
+      </>
+    ),
+  },
+};
+
+export const SegmentedControlFocused: Story = {
+  args: {
+    children: (
+      <>
+        <SegmentedControl.Button buttonKey="red" label="Red" buttonClassName="pseudo-focus-visible"/>
+        <SegmentedControl.Button buttonKey="green" label="Green"/>
+        <SegmentedControl.Button buttonKey="blue" label="Blue"/>
+      </>
+    ),
+  },
+};
+
 export const SegmentedControlDisabled: Story = {
   args: {
     disabled: true,
@@ -66,55 +91,4 @@ export const SegmentedControlDisabledOne: Story = {
       </>
     ),
   },
-};
-
-
-
-
-
-
-const BaseStory: Story = {
-  args: {},
-  render: (args) => <SegmentedControl {...args}/>,
-};
-
-
-export const StandardHover: Story = {
-  ...BaseStory,
-  name: 'SegmentedControl [hover]',
-  args: {
-    ...BaseStory.args,
-    options: baseOptions.map((option, index) => {
-      if (index === 1) {
-        return {
-          ...option,
-          className: 'pseudo-hover',
-        }
-      }
-      return option;
-    }),
-  },
-};
-
-export const StandardFocus: Story = {
-  ...BaseStory,
-  name: 'SegmentedControl [focus]',
-  args: {
-    ...BaseStory.args,
-    options: baseOptions.map((option, index) => {
-      if (index === 1) {
-        return {
-          ...option,
-          className: 'pseudo-focus-visible',
-        }
-      }
-      return option;
-    }),
-  },
-};
-
-export const StandardAllDisabled: Story = {
-  ...BaseStory,
-  name: 'SegmentedControl [disabled]',
-  args: { ...BaseStory.args, disabled: true },
 };

--- a/src/components/forms/controls/SegmentedControl/SegmentedControl.stories.tsx
+++ b/src/components/forms/controls/SegmentedControl/SegmentedControl.stories.tsx
@@ -21,6 +21,7 @@ export default {
   argTypes: {
   },
   args: {
+    defaultButtonKey: 'red',
     children: (
       <>
         <SegmentedControl.Button buttonKey="red" label="Red"/>

--- a/src/components/forms/controls/SegmentedControl/SegmentedControl.stories.tsx
+++ b/src/components/forms/controls/SegmentedControl/SegmentedControl.stories.tsx
@@ -55,7 +55,7 @@ export const SegmentedControlHover: Story = {
   args: {
     children: (
       <>
-        <SegmentedControl.Button buttonKey="red" label="Red" buttonClassName="pseudo-hover"/>
+        <SegmentedControl.Button buttonKey="red" label="Red" className="pseudo-hover"/>
         <SegmentedControl.Button buttonKey="green" label="Green"/>
         <SegmentedControl.Button buttonKey="blue" label="Blue"/>
       </>
@@ -67,7 +67,7 @@ export const SegmentedControlFocused: Story = {
   args: {
     children: (
       <>
-        <SegmentedControl.Button buttonKey="red" label="Red" buttonClassName="pseudo-focus-visible"/>
+        <SegmentedControl.Button buttonKey="red" label="Red" className="pseudo-focus-visible"/>
         <SegmentedControl.Button buttonKey="green" label="Green"/>
         <SegmentedControl.Button buttonKey="blue" label="Blue"/>
       </>

--- a/src/components/forms/controls/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/forms/controls/SegmentedControl/SegmentedControl.tsx
@@ -96,6 +96,11 @@ export type SegmentedControlProps = ComponentProps<'div'> & {
   /** Whether this component should be unstyled. */
   unstyled?: undefined | boolean,
   
+  // Note: currently only supports `small`, but we may introduce a 'medium' default in the future. Make this field
+  // required for now so that we can change the default later.
+  /** The size of the component. */
+  size: 'small',
+  
   /** The default button to select. */
   defaultButtonKey: ButtonKey,
   
@@ -113,6 +118,7 @@ export const SegmentedControl = Object.assign(
     const {
       children,
       unstyled = false,
+      size = 'small',
       defaultButtonKey,
       disabled = false,
       onChange,
@@ -149,8 +155,11 @@ export const SegmentedControl = Object.assign(
     
     // After initial rendering, check whether `defaultButtonKey` refers to one of the rendered buttons
     useEffectOnce(() => {
-      if (!buttonDefsRef.current.has(defaultButtonKey)) {
+      const buttonDef: undefined | ButtonDef = buttonDefsRef.current.get(defaultButtonKey);
+      if (typeof buttonDef === 'undefined' || buttonDef.buttonRef.current === null) {
         console.error(`Unable to find a button matching the specified defaultButtonKey: ${defaultButtonKey}`);
+      } else if (!isElementFocusable(buttonDef.buttonRef.current)) {
+        console.error(`Default button is not focusable: ${defaultButtonKey}`);
       }
     });
     
@@ -203,6 +212,7 @@ export const SegmentedControl = Object.assign(
       })();
       
       if (buttonTarget !== null && buttonTarget !== context.selectedButton) {
+        event.preventDefault();
         context.selectButton(buttonTarget);
       }
     }, [context]);
@@ -217,6 +227,7 @@ export const SegmentedControl = Object.assign(
           className={cx(
             'bk',
             { [cl['bk-segmented-control']]: !unstyled },
+            { [cl['bk-segmented-control--small']]: size === 'small' },
             { [cl['bk-segmented-control--disabled']]: disabled },
             propsRest.className,
           )}

--- a/src/components/forms/controls/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/forms/controls/SegmentedControl/SegmentedControl.tsx
@@ -4,7 +4,7 @@
 
 import * as React from 'react';
 import { mergeRefs, useEffectOnce } from '../../../../util/reactUtil.ts';
-import { type ClassNameArgument, classNames as cx, type ComponentProps } from '../../../../util/componentUtil.ts';
+import { classNames as cx, type ComponentProps } from '../../../../util/componentUtil.ts';
 
 import { Button } from '../../../actions/Button/Button.tsx';
 

--- a/src/components/forms/controls/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/forms/controls/SegmentedControl/SegmentedControl.tsx
@@ -16,6 +16,7 @@ References:
 - https://primer.style/components/segmented-control
 - https://canvas.workday.com/components/buttons/segmented-control
 - https://github.com/adobe/react-spectrum/discussions/7274
+- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/radiogroup_role
 */
 
 export { cl as SegmentedControlClassNames };
@@ -60,12 +61,9 @@ type SegmentedControlButtonProps = ComponentProps<typeof Button> & {
   
   /** The unique key of this button within the segmented control. */
   buttonKey: ButtonKey,
-  
-  /** Class name to apply to the inner `<Button/>` element. */
-  buttonClassName?: undefined | ClassNameArgument,
 };
 const SegmentedControlButton = (props: SegmentedControlButtonProps) => {
-  const { unstyled, buttonKey, buttonClassName, ...propsRest } = props;
+  const { unstyled, buttonKey, ...propsRest } = props;
   
   const buttonRef = React.useRef<React.ComponentRef<typeof Button>>(null);
   const buttonDef = React.useMemo<ButtonDef>(() => ({ buttonKey, buttonRef }), [buttonKey]);
@@ -74,35 +72,27 @@ const SegmentedControlButton = (props: SegmentedControlButtonProps) => {
   const isSelected = context.selectedButton === buttonKey;
   
   return (
-    <li
-      role="presentation"
+    <Button
+      unstyled
+      role="radio"
+      aria-checked={isSelected}
+      tabIndex={isSelected ? 0 : -1} // "Roving" tab index
+      {...propsRest}
+      ref={mergeRefs(buttonRef, propsRest.ref)}
       className={cx(
-        { [cl['bk-segmented-control__item']]: !unstyled },
+        { [cl['bk-segmented-control__button']]: !unstyled },
         propsRest.className,
       )}
-    >
-      <Button
-        unstyled
-        role="radio"
-        aria-checked={isSelected}
-        tabIndex={isSelected ? 0 : -1}
-        {...propsRest}
-        ref={mergeRefs(buttonRef, propsRest.ref)}
-        className={cx(
-          { [cl['bk-segmented-control__button']]: !unstyled },
-          buttonClassName,
-        )}
-        onPress={() => {
-          propsRest.onPress?.();
-          context.selectButton(buttonKey);
-        }}
-        disabled={context.disabled || propsRest.disabled}
-      />
-    </li>
+      onPress={() => {
+        propsRest.onPress?.();
+        context.selectButton(buttonKey);
+      }}
+      disabled={context.disabled || propsRest.disabled}
+    />
   );
 };
 
-export type SegmentedControlProps = ComponentProps<'ul'> & {
+export type SegmentedControlProps = ComponentProps<'div'> & {
   /** Whether this component should be unstyled. */
   unstyled?: undefined | boolean,
   
@@ -219,10 +209,11 @@ export const SegmentedControl = Object.assign(
     
     return (
       <SegmentedControlContext value={context}>
-        <ul
+        <div
           {...propsRest}
           role="radiogroup"
           aria-required
+          aria-orientation="horizontal"
           className={cx(
             'bk',
             { [cl['bk-segmented-control']]: !unstyled },
@@ -232,7 +223,7 @@ export const SegmentedControl = Object.assign(
           onKeyDown={handleKeyDown}
         >
           {children}
-        </ul>
+        </div>
       </SegmentedControlContext>
     );
   },

--- a/src/components/forms/controls/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/forms/controls/SegmentedControl/SegmentedControl.tsx
@@ -3,102 +3,187 @@
 |* the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react';
-import { classNames as cx, type ComponentProps } from '../../../../util/componentUtil.ts';
+import { type ClassNameArgument, classNames as cx, type ComponentProps } from '../../../../util/componentUtil.ts';
 
 import { Button } from '../../../actions/Button/Button.tsx';
 
 import cl from './SegmentedControl.module.scss';
 
 
+/*
+References:
+- https://primer.style/components/segmented-control
+- https://canvas.workday.com/components/buttons/segmented-control
+- https://github.com/adobe/react-spectrum/discussions/7274
+*/
+
 export { cl as SegmentedControlClassNames };
+
+
+export type ButtonKey = string;
+//export type ButtonDef = { buttonKey: ButtonKey, label: string };
+
+export type SegmentedControlContext = {
+  selectedButton: ButtonKey,
+  disabled: boolean,
+  selectButton: (buttonKey: ButtonKey) => void,
+  // getItemProps: ReturnType<typeof useInteractions>['getItemProps'],
+};
+export const SegmentedControlContext = React.createContext<null | SegmentedControlContext>(null);
+export const useSegmentedControlContext = () => {
+  const context = React.use(SegmentedControlContext);
+  if (context === null) { throw new Error(`Missing SegmentedControlContext provider`); }
+  return context;
+};
+
+
+type SegmentedControlButtonProps = ComponentProps<typeof Button> & {
+  /** Whether this component should be unstyled. */
+  unstyled?: undefined | boolean,
+  
+  /** The unique key of this button within the segmented control. */
+  buttonKey: ButtonKey,
+  
+  /** Class name to apply to the inner `<Button/>` element. */
+  buttonClassName?: undefined | ClassNameArgument,
+};
+const SegmentedControlButton = (props: SegmentedControlButtonProps) => {
+  const { unstyled, buttonKey, buttonClassName, ...propsRest } = props;
+  
+  const context = useSegmentedControlContext();
+  
+  return (
+    <li
+      role="presentation"
+      className={cx(
+        { [cl['bk-segmented-control__item']]: !unstyled },
+        propsRest.className,
+      )}
+    >
+      <Button
+        unstyled
+        role="radio"
+        {...propsRest}
+        className={cx(
+          { [cl['bk-segmented-control__button']]: !unstyled },
+          buttonClassName,
+        )}
+        // aria-label={option.label}
+        // label={option.label}
+        onPress={() => { context.selectButton(buttonKey); } }
+        aria-checked={context.selectedButton === buttonKey}
+        disabled={context.disabled || propsRest.disabled}
+      />
+    </li>
+  );
+};
+
+
 
 export type SegmentedOption = {
   label: string,
   value: string,
-  className?: string,
+  className?: undefined | ClassNameArgument,
 };
-export type SegmentedControlProps = React.PropsWithChildren<ComponentProps<'ul'> & {
+
+export type SegmentedControlProps = ComponentProps<'ul'> & {
   /** Whether this component should be unstyled. */
   unstyled?: undefined | boolean,
   
-  /** What options segmented control has */
-  options: Array<string> | Array<SegmentedOption>,
+  ///** What options segmented control has. */
+  //options: Array<string> | Array<SegmentedOption>,
   
-  /** What default option segmented control has */
+  /** What default option segmented control has. */
   defaultValue: string,
   
-  /** Whether segmented control is disabled or not */
+  /** Whether segmented control is disabled or not. */
   disabled?: undefined | boolean,
   
-  /** Event handler for segmented-control button change events. */
+  /** Event handler for segmented control button change events. */
   onChange?: undefined | ((option: string) => void),
-}>;
-/**
- * Set of buttons to switch between various options.
- */
-export const SegmentedControl = (props: SegmentedControlProps) => {
-  const {
-    unstyled = false,
-    options = [],
-    defaultValue,
-    disabled = false,
-    onChange,
-    ...propsRest
-  } = props;
-  
-  const formattedOptions: SegmentedOption[] = React.useMemo(() => {
-    return options.map((option) => {
-      if (typeof option !== 'object' || option === null) {
-        return {
-          label: option,
-          value: option,
-        };
-      }
-      return option;
-    });
-  }, [options]);
-  
-  const initialOption = () => {
-    if (defaultValue && formattedOptions.some(option => option.value === defaultValue)) {
-      return defaultValue;
-    }
-    return formattedOptions[0]?.value;
-  };
-  const [selectedOption, setSelectedOption] = React.useState(initialOption());
-  
-  const handleClick = (option: string) => {
-    if (!disabled) {
-      setSelectedOption(option);
-      onChange?.(option);
-    }
-  };
-  
-  return (
-    <ul
-      {...propsRest}
-      role="radiogroup"
-      className={cx({
-        bk: true,
-        [cl['bk-segmented-control']]: !unstyled,
-        [cl['bk-segmented-control--disabled']]: disabled,
-      }, propsRest.className)}
-    >
-      {formattedOptions.map((option, index) =>
-        // biome-ignore lint/suspicious/noArrayIndexKey: no other unique identifier available
-        <li key={index} role="presentation" className={cl['bk-segmented-control__item']}>
-          <Button
-            role="radio"
-            unstyled
-            className={cx({
-              [cl['bk-segmented-control__toggle']]: true,
-            }, option.className)}
-            aria-label={option.label}
-            label={option.label}
-            onPress={() => { handleClick(option.value); } }
-            aria-checked={selectedOption === option.value ? 'true' : 'false'}
-          />
-        </li>
-      )}
-    </ul>
-  );
 };
+/**
+ * A segmented control is a set of mutually exclusive buttons that can be switched between.
+ */
+export const SegmentedControl = Object.assign(
+  (props: SegmentedControlProps) => {
+    const {
+      children,
+      unstyled = false,
+      options = [],
+      defaultValue,
+      disabled = false,
+      onChange,
+      ...propsRest
+    } = props;
+    
+    const formattedOptions: Array<SegmentedOption> = React.useMemo(() => {
+      return options.map((option) => {
+        if (typeof option !== 'object' || option === null) {
+          return {
+            label: option,
+            value: option,
+          };
+        }
+        return option;
+      });
+    }, [options]);
+    
+    const initialOption = () => {
+      if (defaultValue && formattedOptions.some(option => option.value === defaultValue)) {
+        return defaultValue;
+      }
+      return formattedOptions[0]?.value;
+    };
+    const [selectedOption, setSelectedOption] = React.useState(initialOption());
+    
+    const handleClick = (option: string) => {
+      if (!disabled) {
+        setSelectedOption(option);
+        onChange?.(option);
+      }
+    };
+    
+    const context = React.useMemo<SegmentedControlContext>(() => ({
+      selectedButton: 'red', // FIXME
+      disabled,
+    }), [disabled]);
+    
+    return (
+      <SegmentedControlContext value={context}>
+        <ul
+          {...propsRest}
+          role="radiogroup"
+          className={cx(
+            'bk',
+            { [cl['bk-segmented-control']]: !unstyled },
+            { [cl['bk-segmented-control--disabled']]: disabled },
+            propsRest.className,
+          )}
+        >
+          {/*formattedOptions.map((option, index) =>
+            // biome-ignore lint/suspicious/noArrayIndexKey: no other unique identifier available
+            <li key={index} role="presentation" className={cl['bk-segmented-control__item']}>
+              <Button
+                role="radio"
+                unstyled
+                className={cx(
+                  [cl['bk-segmented-control__toggle']],
+                  option.className,
+                )}
+                aria-label={option.label}
+                label={option.label}
+                onPress={() => { handleClick(option.value); } }
+                aria-checked={selectedOption === option.value ? 'true' : 'false'}
+              />
+            </li>
+          )*/}
+          {children}
+        </ul>
+      </SegmentedControlContext>
+    );
+  },
+  {
+    Button: SegmentedControlButton,
+  },
+);

--- a/src/components/tables/MultiSearch/MultiSearch.tsx
+++ b/src/components/tables/MultiSearch/MultiSearch.tsx
@@ -492,7 +492,7 @@ export const SearchInput = (props: SearchInputProps) => {
     inputRef,
     onFocus,
     onBlur,
-    ...restProps
+    ...propsRest
   } = props;
   
   const {
@@ -571,13 +571,13 @@ export const SearchInput = (props: SearchInputProps) => {
         </span>
       }
       <Input
-        ref={mergeRefs(props.ref, inputRef)}
         placeholder={renderPlaceholder()}
         className="bk-search-input__input"
         onKeyDown={onKeyDown}
         onFocus={handleFocus}
         onBlur={handleBlur}
-        {...restProps}
+        {...propsRest}
+        ref={mergeRefs(inputRef, propsRest.ref)}
       />
     </div>
   );

--- a/src/styling/global/accessibility.scss
+++ b/src/styling/global/accessibility.scss
@@ -52,7 +52,9 @@
   }
 }
 
-@mixin sr-only {
+// Hide an element visually, but keep it in the accessibility tree (sometimes also called "sr-only").
+// https://www.w3.org/WAI/tutorials/forms/labels/#note-on-hiding-elements
+@mixin visually-hidden {
   border: 0;
   clip: rect(1px, 1px, 1px, 1px);
   clip-path: inset(50%);

--- a/src/styling/global/reset.scss
+++ b/src/styling/global/reset.scss
@@ -55,6 +55,10 @@
     
     button {
       cursor: pointer;
+      
+      &:disabled {
+        cursor: not-allowed;
+      }
     }
     
     /*

--- a/src/typography/BodyText/BodyText.stories.tsx
+++ b/src/typography/BodyText/BodyText.stories.tsx
@@ -107,7 +107,7 @@ export const WithComponents: Story = {
           </div>
         </Panel>
         
-        <SegmentedControl defaultButtonKey="test-1" aria-label="Test segmented control">
+        <SegmentedControl size="small" defaultButtonKey="test-1" aria-label="Test segmented control">
           <SegmentedControl.Button buttonKey="test-1" label="Test 1"/>
           <SegmentedControl.Button buttonKey="test-2" label="Test 2"/>
           <SegmentedControl.Button buttonKey="test-3" label="Test 3"/>

--- a/src/typography/BodyText/BodyText.stories.tsx
+++ b/src/typography/BodyText/BodyText.stories.tsx
@@ -107,10 +107,11 @@ export const WithComponents: Story = {
           </div>
         </Panel>
         
-        <SegmentedControl
-          options={['Test 1', 'Test 2']}
-          defaultValue="Test 1"
-        />
+        <SegmentedControl defaultButtonKey="test-1" aria-label="Test segmented control">
+          <SegmentedControl.Button buttonKey="test-1" label="Test 1"/>
+          <SegmentedControl.Button buttonKey="test-2" label="Test 2"/>
+          <SegmentedControl.Button buttonKey="test-3" label="Test 3"/>
+        </SegmentedControl>
       </>
     ),
   },


### PR DESCRIPTION
Resolves #137, and part of #116.

This PR:
- Updates `SegmentedControl` with a more standard keyboard interactions implementation that conforms to [ARIA guidelines](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/radiogroup_role#keyboard_interactions).
- Refactors the component to use composition rather than a JSON prop for the child items.
- Adds the ability to use an icon as a segmented control button (and buttons in general).