### PR TITLE
Re-enable Chromatic CI job

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   chromatic:
-    if: false # Temporarily disable until https://github.com/fortanix/baklava/issues/81 is resolved
+    #if: false # Uncomment to disable this job
     name: Run Chromatic
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Our Chromatic has been upgraded to the latest infrastructure, in particular [version 7](https://www.chromatic.com/docs/infrastructure-release-notes/) which comes with Chrome v132. So we can now re-enable our Chromatic CI job.

Resolves #81 