### PR TITLE
Implement `Card.HeadingLink` component

### DIFF
--- a/src/components/containers/Card/Card.module.scss
+++ b/src/components/containers/Card/Card.module.scss
@@ -3,6 +3,7 @@
 |* the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 @use '../../../styling/defs.scss' as bk;
+@use '../../../typography/Heading/Heading.mixins.scss' as heading;
 
 @mixin bk-card($name: bk-card) {
   --bk-card-background-color: #{bk.$theme-card-background-default};
@@ -17,6 +18,12 @@
   background: var(--bk-card-background-color);
   border: bk.$size-1 solid var(--bk-card-border-color);
   border-radius: bk.$radius-m;
+  
+  .#{$name}__heading-link {
+    display: block;
+    cursor: pointer;
+    @include heading.h5;
+  }
   
   .#{$name}__heading {
     margin-block-end: bk.$spacing-5;

--- a/src/components/containers/Card/Card.stories.tsx
+++ b/src/components/containers/Card/Card.stories.tsx
@@ -4,6 +4,9 @@
 
 import * as React from 'react';
 
+import { LoremIpsum } from '../../../util/storybook/LoremIpsum.tsx';
+import { DummyBkLinkWithNotify } from '../../../util/storybook/StorybookLink.tsx';
+import { LayoutDecorator } from '../../../util/storybook/LayoutDecorator.tsx';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Banner } from '../Banner/Banner.tsx';
@@ -13,11 +16,6 @@ import { Card } from './Card.tsx';
 
 type CardArgs = React.ComponentProps<typeof Card>;
 type Story = StoryObj<typeof Card>;
-
-const lorem = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
-  dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-  consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-  Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`;
 
 export default {
   component: Card,
@@ -29,20 +27,52 @@ export default {
   argTypes: {},
   args: {
     unstyled: false,
-    children: <><Card.Heading>Card</Card.Heading>{lorem}</>,
+    children: <LoremIpsum/>,
   },
   render: (args) => <Card {...args}/>,
 } satisfies Meta<CardArgs>;
 
 
-export const Standard: Story = {
-  decorators: [
-    Story => <div style={{ inlineSize: '30vw' }}><Story/></div>
-  ],
+export const CardStandard: Story = {
+  decorators: [Story => <LayoutDecorator size="small"><Story/></LayoutDecorator>],
+};
+
+export const CardWithHeading: Story = {
+  decorators: [Story => <LayoutDecorator size="small"><Story/></LayoutDecorator>],
+  args: {
+    children: (
+      <>
+        <Card.Heading>Heading</Card.Heading>
+        <LoremIpsum/>
+      </>
+    ),
+  },
+};
+
+export const CardWithHeadingLink: Story = {
+  decorators: [Story => <LayoutDecorator size="small"><Story/></LayoutDecorator>],
+  args: {
+    children: (
+      <>
+        <Card.HeadingLink Link={DummyBkLinkWithNotify}>A heading that acts as a link</Card.HeadingLink>
+        <LoremIpsum/>
+      </>
+    ),
+  },
 };
 
 /** Multiple cards in a grid. */
-export const Multiple: Story = {
+export const CardGrid: Story = {
+  decorators: [
+    Story => (
+      <LayoutDecorator size="x-large" style={{ display: 'flex', flexFlow: 'column', gap: '1.2rem' }}>
+        <Banner variant="info" title="Note:">
+          Cards have no margin by default. Use a flex/grid container to space the cards.
+        </Banner>
+        <Story/>
+      </LayoutDecorator>
+    ),
+  ],
   render: (args) => (
     <div style={{
       display: 'grid',
@@ -50,18 +80,8 @@ export const Multiple: Story = {
       gridTemplateColumns: 'repeat(auto-fit, minmax(min(30vw, 100%), 1fr))',
     }}>
       <Card {...args}><Card.Heading>Card 1</Card.Heading>Card content.</Card>
-      <Card {...args}><Card.Heading>Card 2</Card.Heading>{lorem}</Card>
+      <Card {...args}><Card.Heading>Card 2</Card.Heading><LoremIpsum/></Card>
       <Card {...args}><Card.Heading>Card 3</Card.Heading>Card content.</Card>
     </div>
   ),
-  decorators: [
-    Story => (
-      <div style={{ inlineSize: '70vw', display: 'flex', flexFlow: 'column', gap: '1.2rem' }}>
-        <Banner variant="info" title="Note:">
-          Cards have no margin by default. Use a flex/grid container to space the cards.
-        </Banner>
-        <Story/>
-      </div>
-    ),
-  ],
 };

--- a/src/components/containers/Card/Card.tsx
+++ b/src/components/containers/Card/Card.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import { classNames as cx, type ComponentProps } from '../../../util/componentUtil.ts';
 
 import { H5 } from '../../../typography/Heading/Heading.tsx';
-import { Button } from '../../actions/Button/Button.tsx';
+import { Link as LinkDefault } from '../../actions/Link/Link.tsx';
 
 import cl from './Card.module.scss';
 
@@ -14,15 +14,28 @@ import cl from './Card.module.scss';
 export { cl as CardClassNames };
 
 
-export type CardHeadingProps = React.PropsWithChildren<ComponentProps<typeof H5>>;
+export type CardHeadingProps = ComponentProps<typeof H5>;
 export const CardHeading = (props: CardHeadingProps) => {
   return <H5 {...props} className={cx(cl['bk-card__heading'], props.className)}/>;
 };
 
-export type CardProps = React.PropsWithChildren<ComponentProps<'section'> & {
+export type CardHeadingLinkProps = ComponentProps<typeof LinkDefault> & {
+  Link?: undefined | typeof LinkDefault,
+};
+export const CardHeadingLink = ({ Link = LinkDefault, ...propsRest }: CardHeadingLinkProps) => {
+  return (
+    <Link
+      unstyled
+      {...propsRest}
+      className={cx(cl['bk-card__heading'], cl['bk-card__heading-link'], propsRest.className)}
+    />
+  );
+};
+
+export type CardProps = ComponentProps<'section'> & {
   /** Whether this component should be unstyled. */
   unstyled?: undefined | boolean,
-}>;
+};
 /**
  * Card component, a container similar to a panel but smaller and usually used in a list or grid.
  */
@@ -45,5 +58,6 @@ export const Card = Object.assign(
   },
   {
     Heading: CardHeading,
+    HeadingLink: CardHeadingLink,
   },
 );

--- a/src/util/storybook/LayoutDecorator.module.scss
+++ b/src/util/storybook/LayoutDecorator.module.scss
@@ -13,6 +13,7 @@
     
     &.util-layout-decorator--small { max-inline-size: 60ch; }
     &.util-layout-decorator--large { max-inline-size: 100ch; }
+    &.util-layout-decorator--x-large { max-inline-size: 140ch; }
     
     &.util-layout-decorator--resizable {
       padding-block-end: 10px; // Make space for the resize control in the corner

--- a/src/util/storybook/LayoutDecorator.tsx
+++ b/src/util/storybook/LayoutDecorator.tsx
@@ -11,7 +11,7 @@ import cl from './LayoutDecorator.module.scss';
  * Utility component to wrap around storybook stories to provide a nicer base layout.
  */
 export type LayoutDecoratorProps = ComponentProps<'div'> & {
-  size?: undefined | 'small' | 'medium' | 'large',
+  size?: undefined | 'small' | 'medium' | 'large' | 'x-large',
   resize?: undefined | 'none' | 'inline' | 'block' | 'both',
 };
 export const LayoutDecorator = (props: LayoutDecoratorProps) => {
@@ -29,6 +29,7 @@ export const LayoutDecorator = (props: LayoutDecoratorProps) => {
         { [cl['util-layout-decorator']]: true },
         { [cl['util-layout-decorator--small']]: size === 'small' },
         { [cl['util-layout-decorator--large']]: size === 'large' },
+        { [cl['util-layout-decorator--x-large']]: size === 'x-large' },
         { [cl['util-layout-decorator--resizable']]: resize !== 'none' },
         propsRest.className,
       )}

--- a/src/util/storybook/StorybookLink.tsx
+++ b/src/util/storybook/StorybookLink.tsx
@@ -4,6 +4,26 @@
 
 import * as React from 'react';
 
+import { notify } from '../../components/overlays/ToastProvider/ToastProvider.tsx';
+import { Link } from '../../components/actions/Link/Link.tsx';
 
-export const DummyLink = (props: React.ComponentProps<'a'>) =>
-  <a href="/" onClick={event => { event.preventDefault(); }} {...props}/>;
+
+const handleClick = (event: React.MouseEvent) => {
+  event.preventDefault();
+};
+const handleClickWithNotify = (event: React.MouseEvent) => {
+  event.preventDefault();
+  notify.info('Clicked the link');
+};
+
+type DummyLinkProps = React.ComponentProps<'a'>;
+export const DummyLink = (props: DummyLinkProps) =>
+  <a href="/" onClick={handleClick} {...props}/>;
+
+type DummyBkLinkProps = React.ComponentProps<typeof Link>;
+export const DummyBkLink = (props: DummyBkLinkProps) =>
+  <Link href="/" onClick={handleClick} {...props}/>;
+
+type DummyBkLinkWithNotifyProps = React.ComponentProps<typeof Link>;
+export const DummyBkLinkWithNotify = (props: DummyBkLinkWithNotifyProps) =>
+  <Link href="/" onClick={handleClickWithNotify} {...props}/>;


### PR DESCRIPTION
Implements a variant of `Card.Heading` that is semantically a `Link`.

<img width="693" alt="Screenshot 2025-05-19 at 19 20 26" src="https://github.com/user-attachments/assets/8fead0f0-58c6-4c2f-ba49-2c350c37694d" />
