### PR TITLE
Implement `TextLine` component

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -57,6 +57,7 @@ const preview = {
             ],
             'text',
             [
+              'TextLine',
               'Tag',
             ],
             'containers',

--- a/app/lib.ts
+++ b/app/lib.ts
@@ -70,6 +70,7 @@ export { ProgressBar } from '../src/components/graphics/ProgressBar/ProgressBar.
 export { Spinner } from '../src/components/graphics/Spinner/Spinner.tsx';
 
 // Text
+export { TextLine } from '../src/components/text/TextLine/TextLine.tsx';
 export { Tag } from '../src/components/text/Tag/Tag.tsx';
 
 // Lists

--- a/src/components/overlays/Tooltip/TooltipProvider.tsx
+++ b/src/components/overlays/Tooltip/TooltipProvider.tsx
@@ -23,7 +23,7 @@ export type TooltipProviderProps = Omit<TooltipProps, 'children'> & {
    * The tooltip message. If `null`, the tooltip will not be shown at all. This is useful in case the tooltip should
    * be shown conditionally.
    */
-  tooltip: null | React.ReactNode,
+  tooltip: null | React.ReactNode | (() => React.ReactNode),
   
   /** Where to show the tooltip relative to the anchor. */
   // here we are not using Placement as exposed from Popover because Tooltip only supports a subset of Popover's default placements.
@@ -62,6 +62,7 @@ export const TooltipProvider = (props: TooltipProviderProps) => {
   const {
     context,
     isMounted,
+    isOpen,
     refs,
     floatingStyles,
     getReferenceProps,
@@ -88,8 +89,14 @@ export const TooltipProvider = (props: TooltipProviderProps) => {
     }
   }, [isMounted, onTooltipActivated, onTooltipDeactivated]);
   
-  const renderTooltip = () => {
-    if (!isMounted || !tooltip) { return null; }
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Depend on `isOpen` to rerender content on open
+  const tooltipContent = React.useMemo(() => {
+    return typeof tooltip === 'function' ? tooltip() : tooltip;
+  }, [tooltip, isOpen]);
+  
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Need to exclude `tooltipProps`
+  const tooltipRendered = React.useMemo(() => {
+    if (!isMounted || !tooltipContent) { return null; }
     
     const arrowClassName = (() => {
       const placement = activePlacement.split('-')[0] as 'top' | 'right' | 'bottom' | 'left';
@@ -143,7 +150,7 @@ export const TooltipProvider = (props: TooltipProviderProps) => {
         } as React.CSSProperties}
         size={size}
       >
-        {tooltip}
+        {tooltipContent}
         {/*
         Fake arrow element for position tracking, the real arrow is drawn using `border-image`.
         Note: `floating-ui` has a `FloatingArrow` component using a positioned <svg> arrow, but this doesn't work if
@@ -152,9 +159,20 @@ export const TooltipProvider = (props: TooltipProviderProps) => {
         <span ref={arrowRef} hidden aria-hidden/>
       </Tooltip>
     );
-  };
+  }, [
+    isMounted,
+    tooltipContent,
+    activePlacement,
+    arrow,
+    floatingStyles,
+    getFloatingProps,
+    refs.setFloating,
+    size,
+    //tooltipProps, // Changes on every render
+  ]);
   
-  const renderAnchor = () => {
+  // Note: memoize this, so that the anchor does not get rerendered every time the floating element position changes
+  const anchorRendered = React.useMemo(() => {
     const renderPropArg: GetReferenceProps = (userProps?: undefined | React.HTMLProps<Element>) => {
       const userPropsRef: undefined | string | React.Ref<Element> = userProps?.ref ?? undefined;
       if (typeof userPropsRef === 'string') {
@@ -184,12 +202,16 @@ export const TooltipProvider = (props: TooltipProviderProps) => {
     
     console.error(`Invalid children passed to TooltipContainer, expected a render prop or single child element.`);
     return children;
-  };
+  }, [
+    children,
+    refs.setReference,
+    getReferenceProps,
+  ]);
   
   return (
     <>
-      {renderTooltip()}
-      {renderAnchor()}
+      {tooltipRendered}
+      {anchorRendered}
     </>
   );
 };

--- a/src/components/text/TextLine/TextLine.module.scss
+++ b/src/components/text/TextLine/TextLine.module.scss
@@ -1,0 +1,13 @@
+/* Copyright (c) Fortanix, Inc.
+|* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of
+|* the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@use '../../../styling/defs.scss' as bk;
+
+@layer baklava.components {
+  .bk-text-line {
+    @include bk.component-base(bk-text-line);
+    
+    @include bk.text-one-line;
+  }
+}

--- a/src/components/text/TextLine/TextLine.stories.tsx
+++ b/src/components/text/TextLine/TextLine.stories.tsx
@@ -1,0 +1,59 @@
+/* Copyright (c) Fortanix, Inc.
+|* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of
+|* the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { loremIpsumSentence } from '../../../util/storybook/LoremIpsum.tsx';
+
+import { TextLine } from './TextLine.tsx';
+
+
+type TextLineArgs = React.ComponentProps<typeof TextLine>;
+type Story = StoryObj<TextLineArgs>;
+
+export default {
+  component: TextLine,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {},
+  args: {
+    children: loremIpsumSentence,
+  },
+  render: (args) => <TextLine {...args}/>,
+} satisfies Meta<TextLineArgs>;
+
+
+/** The `TextLine` element displays a single line of text content. */
+export const TextLineStandard: Story = {};
+
+/** When the text overflows its container, it will be truncated with an ellipsis. */
+export const TextLineWithOverflow: Story = {
+  decorators: [
+    Story => (
+      <div style={{ display: 'grid', resize: 'inline', overflow: 'hidden', width: '30ch' }}>
+        <Story/>
+      </div>
+    ),
+  ],
+  args: {
+    showOverflowTooltip: false,
+  },
+};
+
+/** In case of overflow, a tooltip can be shown on hover to show the full text content. */
+export const TextLineWithOverflowTooltip: Story = {
+  decorators: [
+    Story => (
+      <div style={{ display: 'grid', resize: 'inline', overflow: 'hidden', width: '30ch' }}>
+        <Story/>
+      </div>
+    ),
+  ],
+  args: {
+    showOverflowTooltip: true,
+  },
+};

--- a/src/components/text/TextLine/TextLine.tsx
+++ b/src/components/text/TextLine/TextLine.tsx
@@ -1,0 +1,56 @@
+/* Copyright (c) Fortanix, Inc.
+|* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of
+|* the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react';
+import { classNames as cx, type ComponentProps } from '../../../util/componentUtil.ts';
+
+import { TooltipProvider } from '../../overlays/Tooltip/TooltipProvider.tsx';
+
+import cl from './TextLine.module.scss';
+
+
+export { cl as TextLineClassNames };
+
+export type TextLineProps = ComponentProps<'span'> & {
+  /** Whether to show a tooltip with the full text content in case of overflow. Default: true. */
+  showOverflowTooltip?: undefined | boolean,
+};
+/**
+ * A single-line piece of text.
+ */
+export const TextLine = (props: TextLineProps) => {
+  const { showOverflowTooltip = true, ...propsRest } = props;
+  
+  const elementRef = React.useRef<null | HTMLSpanElement>(null);
+  
+  const renderTooltip = React.useCallback(() => {
+    const element = elementRef.current;
+    if (!element) { return; }
+    
+    const hasOverflow = element.scrollWidth > element.clientWidth;
+    return hasOverflow ? (element.innerText ?? null) : null;
+  }, []);
+  
+  const text = (
+    <span
+      ref={elementRef}
+      {...propsRest}
+      className={cx(
+        'bk',
+        cl['bk-text-line'],
+        propsRest.className,
+      )}
+    />
+  );
+  
+  if (showOverflowTooltip) {
+    return (
+      <TooltipProvider tooltip={renderTooltip}>
+        {text}
+      </TooltipProvider>
+    );
+  }
+  
+  return text;
+};


### PR DESCRIPTION
Implements a new component `TextLine`, which displays some text content constrained to a single line (with text ellipsis), and optionally will show a tooltip on hover for truncated text, in order to show the full content.

![Screenshot 2025-05-20 at 22 33 50](https://github.com/user-attachments/assets/0f89e228-c918-4997-934c-fb4d97d77074)

Resolves #237.