### PR TITLE
Add `flat` property for `Card` and improve the nesting logic

### DIFF
--- a/src/components/containers/Card/Card.module.scss
+++ b/src/components/containers/Card/Card.module.scss
@@ -11,24 +11,35 @@
   
   overflow: hidden;
   
-  min-block-size: bk.$spacing-16;
-  padding: bk.$spacing-4;
-  padding-block-end: bk.$spacing-8;
-  
-  background: var(--bk-card-background-color);
-  border: bk.$size-1 solid var(--bk-card-border-color);
-  border-radius: bk.$radius-m;
-  
-  .#{$name}__heading-link {
-    display: block;
-    cursor: pointer;
-    @include heading.h5;
+  &:not(.#{$name}--flat) {
+    min-block-size: bk.$spacing-16;
+    padding: bk.$spacing-4;
+    padding-block-end: bk.$spacing-8;
+    
+    background: var(--bk-card-background-color);
+    border: bk.$size-1 solid var(--bk-card-border-color);
+    border-radius: bk.$radius-m;
   }
   
+  @include bk.flex-column;
+  
   .#{$name}__heading {
+    &.#{$name}__heading-link {
+      align-self: start;
+      max-inline-size: 100%;
+      cursor: pointer;
+      @include heading.h5;
+    }
+    
+    &, &.#{$name}__heading-link { // Note: need the extra specificity to override the above
+      @include bk.text-one-line;
+    }
+    
     margin-block-end: bk.$spacing-5;
-    text-wrap: nowrap;
-    text-overflow: ellipsis;
+  }
+  
+  &.#{$name}--flat > .#{$name}__heading {
+    margin-block-end: bk.$spacing-1;
   }
 }
 

--- a/src/components/containers/Card/Card.stories.tsx
+++ b/src/components/containers/Card/Card.stories.tsx
@@ -4,7 +4,7 @@
 
 import * as React from 'react';
 
-import { LoremIpsum } from '../../../util/storybook/LoremIpsum.tsx';
+import { LoremIpsum, loremIpsumSentence } from '../../../util/storybook/LoremIpsum.tsx';
 import { DummyBkLinkWithNotify } from '../../../util/storybook/StorybookLink.tsx';
 import { LayoutDecorator } from '../../../util/storybook/LayoutDecorator.tsx';
 import type { Meta, StoryObj } from '@storybook/react';
@@ -49,12 +49,36 @@ export const CardWithHeading: Story = {
   },
 };
 
+export const CardWithHeadingOverflow: Story = {
+  decorators: [Story => <LayoutDecorator size="small"><Story/></LayoutDecorator>],
+  args: {
+    children: (
+      <>
+        <Card.Heading>{loremIpsumSentence}</Card.Heading>
+        <LoremIpsum/>
+      </>
+    ),
+  },
+};
+
 export const CardWithHeadingLink: Story = {
   decorators: [Story => <LayoutDecorator size="small"><Story/></LayoutDecorator>],
   args: {
     children: (
       <>
         <Card.HeadingLink Link={DummyBkLinkWithNotify}>A heading that acts as a link</Card.HeadingLink>
+        <LoremIpsum/>
+      </>
+    ),
+  },
+};
+
+export const CardWithHeadingLinkOverflow: Story = {
+  decorators: [Story => <LayoutDecorator size="small"><Story/></LayoutDecorator>],
+  args: {
+    children: (
+      <>
+        <Card.HeadingLink Link={DummyBkLinkWithNotify}>{loremIpsumSentence}</Card.HeadingLink>
         <LoremIpsum/>
       </>
     ),
@@ -92,14 +116,14 @@ export const CardNested: Story = {
     children: (
       <>
         <Card.Heading>A parent card</Card.Heading>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)' }}>
-          <Card unstyled>
-            <Card.Heading>A nested card</Card.Heading>
-            Content
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 50%)', gridGap: '1.5ch' }}>
+          <Card flat>
+            <Card.HeadingLink Link={DummyBkLinkWithNotify}>A nested card</Card.HeadingLink>
+            <LoremIpsum/>
           </Card>
-          <Card unstyled>
-            <Card.Heading>Another nested card</Card.Heading>
-            Content
+          <Card flat>
+            <Card.HeadingLink Link={DummyBkLinkWithNotify}>Another nested card</Card.HeadingLink>
+            <LoremIpsum/>
           </Card>
         </div>
       </>

--- a/src/components/containers/Card/Card.tsx
+++ b/src/components/containers/Card/Card.tsx
@@ -35,13 +35,16 @@ export const CardHeadingLink = ({ Link = LinkDefault, ...propsRest }: CardHeadin
 export type CardProps = ComponentProps<'section'> & {
   /** Whether this component should be unstyled. */
   unstyled?: undefined | boolean,
+  
+  /** If enabled, removes the outside border/padding. For use in nested contexts. Default: false. */
+  flat?: undefined | boolean,
 };
 /**
  * Card component, a container similar to a panel but smaller and usually used in a list or grid.
  */
 export const Card = Object.assign(
   (props: CardProps) => {
-    const { children, unstyled = false, ...propsRest } = props;
+    const { children, unstyled = false, flat = false, ...propsRest } = props;
     
     return (
       <section
@@ -49,6 +52,7 @@ export const Card = Object.assign(
         className={cx(
           'bk',
           { [cl['bk-card']]: !unstyled },
+          { [cl['bk-card--flat']]: flat },
           propsRest.className,
         )}
       >


### PR DESCRIPTION
This PR:

- Adds a `flat` property to `Card` to remove the exterior box properties, useful for nesting.
- Update `Card.HeadingLink` so that it doesn't span the entire width.

Resolves #244.