### PR TITLE
Hide input caret in Firefox for read-only `Select` input

### DIFF
--- a/src/components/forms/controls/Select/Select.module.scss
+++ b/src/components/forms/controls/Select/Select.module.scss
@@ -15,6 +15,7 @@
       
       &:read-only {
         user-select: none;
+        caret-color: transparent; // Note: the caret is still shown in some browsers for readonly inputs (e.g. Firefox)
         
         // Note: `user-select` does not seem to work for `input`, instead we can make the highlight color transparent
         &::selection {


### PR DESCRIPTION
In the read-only input that's being used as part of `Select`, the input caret was visible in Firefox. Fixed it by making the caret transparent.