### PR TITLE
Fix issue with `TextLine` overflow logic

### DIFF
--- a/src/components/text/TextLine/TextLine.module.scss
+++ b/src/components/text/TextLine/TextLine.module.scss
@@ -9,5 +9,6 @@
     @include bk.component-base(bk-text-line);
     
     @include bk.text-one-line;
+    display: inline-block;
   }
 }


### PR DESCRIPTION
Resolves #302

Issue here was due to use of an inline `<span>` element. The `scrollWidth` property is `0` in this case in Firefox (though not in Chrome). Resolved by converting the element into an `inline-block`.