### PR TITLE
Multi Select Empty Footer

### DIFF
--- a/src/components/tables/MultiSearch/MultiSearch.tsx
+++ b/src/components/tables/MultiSearch/MultiSearch.tsx
@@ -409,6 +409,7 @@ export const Suggestions = (props: SuggestionProps) => {
       open={active}
       onOpenChange={handleOpenChange}
       anchorRef={elementRef as React.RefObject<HTMLElement | null>}
+      placeholderEmpty={null}
     />
   );
 };


### PR DESCRIPTION
resolved #309 

This is a quick work around to fix the empty footer at all places in the Multi Select.