### PR TITLE
Add a table text-cell wrapper with `display: flex`

### DIFF
--- a/src/components/tables/DataTable/table/DataTable.module.scss
+++ b/src/components/tables/DataTable/table/DataTable.module.scss
@@ -24,14 +24,19 @@
       }
       
       td {
+        overflow: hidden;
         padding: bk.$spacing-5 bk.$spacing-2;
-        vertical-align: middle;
-        white-space: nowrap; // Prevent wrapping by default, can override this on case-by-case basis
-        overflow: hidden; // Hide overflow by default; may need to override this for things like local dropdown menus
         
-        // *If* `white-space: wrap` is enabled, then allow wrapping mid-word if necessary, to prevent overflow caused
-        // by a long word without spaces/hyphens/etc.
-        overflow-wrap: anywhere;
+        // Note: need a wrapper div for this because setting a different `display` on a `<td>` will break the table
+        .bk-data-table__text-cell {
+          // The following are needed for `<TextLine>` to work
+          overflow: hidden;
+          display: flex;
+          
+          > * {
+            min-inline-size: 0;
+          }
+        }
       }
       
       thead {

--- a/src/components/tables/DataTable/table/DataTable.tsx
+++ b/src/components/tables/DataTable/table/DataTable.tsx
@@ -116,7 +116,9 @@ export const DataTable = <D extends object>(props: DataTableProps<D>) => {
                 const { key: cellKey, ...cellProps } = cell.getCellProps();
                 return (
                   <td {...cellProps} key={cellKey}>
-                    {cell.render('Cell')}
+                    <div className={cx(cl['bk-data-table__text-cell'])}>
+                      {cell.render('Cell')}
+                    </div>
                   </td>
                 );
               })}

--- a/src/components/text/TextLine/TextLine.tsx
+++ b/src/components/text/TextLine/TextLine.tsx
@@ -46,7 +46,7 @@ export const TextLine = (props: TextLineProps) => {
   
   if (showOverflowTooltip) {
     return (
-      <TooltipProvider tooltip={renderTooltip}>
+      <TooltipProvider tooltip={renderTooltip} triggerAction="click">
         {text}
       </TooltipProvider>
     );

--- a/src/components/text/TextLine/TextLine.tsx
+++ b/src/components/text/TextLine/TextLine.tsx
@@ -46,7 +46,7 @@ export const TextLine = (props: TextLineProps) => {
   
   if (showOverflowTooltip) {
     return (
-      <TooltipProvider tooltip={renderTooltip} triggerAction="click">
+      <TooltipProvider tooltip={renderTooltip}>
         {text}
       </TooltipProvider>
     );


### PR DESCRIPTION
Currently, adding a `TextLine` component directly in a table cell (`<td>`) doesn't work, since the `<td>` is not a flex parent. This PR adds a flex container parent for all table cells by default.