### PR TITLE
Disable menu transitions for now to fix positioning issue

### DIFF
--- a/src/components/overlays/MenuProvider/MenuProvider.module.scss
+++ b/src/components/overlays/MenuProvider/MenuProvider.module.scss
@@ -11,16 +11,19 @@
     &[popover] {
       &:not(:popover-open) { display: none; }
       
+      /*
+      // TEMP: disabled animations until we fix the brief "flash" of mis-positioned overlays in floating-ui
       @media (prefers-reduced-motion: no-preference) {
         transition:
           display var(--bk-menu-transition-duration) allow-discrete,
           overlay var(--bk-menu-transition-duration) allow-discrete,
           opacity var(--bk-menu-transition-duration) ease-out,
           translate var(--bk-menu-transition-duration) ease-out;
-          /* transform */ /* Note: don't animate `transform` with floating-ui, since it relies on it for positioning */
+          //transform // Note: don't animate `transform` with floating-ui, since it relies on it for positioning
         opacity: 0;
         //translate: 0 -1rem;
       }
+      */
       
       &:popover-open {
         opacity: 1;

--- a/src/components/tables/MultiSearch/MultiSearch.tsx
+++ b/src/components/tables/MultiSearch/MultiSearch.tsx
@@ -2,7 +2,6 @@
 |* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of
 |* the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import * as Random from '../../../util/random.ts';
 import * as ObjectUtil from '../../../util/objectUtil.ts';
 import {
   isEqual,


### PR DESCRIPTION
This PR disabled CSS transitions on `MenuProvider`, since there's an issue in certain browsers where the element will briefly be mis-positioned while the transition happens. See #252 for instance.