### PR TITLE
Fix the table pagination input sizing in browsers with field-sizing support

### DIFF
--- a/src/components/tables/DataTable/pagination/Pagination.module.scss
+++ b/src/components/tables/DataTable/pagination/Pagination.module.scss
@@ -35,21 +35,30 @@
       }
     }
     .pagination__page-input {
-      min-inline-size: bk.$spacing-8;
       border: bk.$size-1 solid bk.$theme-pagination-border-default;
       border-radius: bk.$size-2;
       text-align: center;
       
-      // Try to hide the number spin controls
-      // https://stackoverflow.com/questions/3790935/can-i-hide-the-html5-number-input-s-spin-box
-      &input[type="number" i], input[type="number" i] {
-        // stylelint-disable-next-line property-no-vendor-prefix
-        -moz-appearance: textfield;
-        &::-webkit-outer-spin-button,
-        &::-webkit-inner-spin-button {
+      .pagination__page-input__input {
+        @supports (field-sizing: content) {
+          field-sizing: content;
+          min-inline-size: 5ch;
+        }
+        @supports not (field-sizing: content) {
+          inline-size: 5ch;
+        }
+        
+        &[type="number"] {
+          // Try to hide the number spin controls
+          // https://stackoverflow.com/questions/3790935/can-i-hide-the-html5-number-input-s-spin-box
           // stylelint-disable-next-line property-no-vendor-prefix
-          -webkit-appearance: none;
-          margin: 0; /* <-- Apparently some margin are still there even though it's hidden */
+          -moz-appearance: textfield;
+          &::-webkit-outer-spin-button,
+          &::-webkit-inner-spin-button {
+            // stylelint-disable-next-line property-no-vendor-prefix
+            -webkit-appearance: none;
+            margin: 0; /* <-- Apparently some margin are still there even though it's hidden */
+          }
         }
       }
     }

--- a/src/components/tables/DataTable/pagination/Pagination.tsx
+++ b/src/components/tables/DataTable/pagination/Pagination.tsx
@@ -36,11 +36,19 @@ export const Pagination = ({ pageSizeOptions }: PaginationProps) => {
   - table.previousPage
   - table.setPageSize
   */
-
+  
+  const updatePage = React.useCallback(() => {
+    const requestedIndex = Number.isSafeInteger(pageIndexIndicator) ? pageIndexIndicator - 1 : 0;
+    const targetIndex: number = Math.max(0, Math.min(table.pageCount - 1, requestedIndex));
+    
+    table.gotoPage(targetIndex);
+    setPageIndexIndicator(targetIndex + 1);
+  }, [pageIndexIndicator, table.pageCount, table.gotoPage]);
+  
   return (
     <div className={cx(cl['bk-pagination'])}>
       <PaginationSizeSelector pageSizeOptions={pageSizeOptions} />
-
+      
       <div className={cx(cl['pager'], cl['pager--indexed'])}>
         <IconButton
           className={cx(cl['pager__nav'])}
@@ -63,21 +71,20 @@ export const Pagination = ({ pageSizeOptions }: PaginationProps) => {
               setPageIndexIndicator(pageIndexIndicator - 1);
             }}
           />
-
+          
           <Input
             type="number"
             automaticResize
             className={cx(cl['pagination__page-input'])}
+            inputProps={{ className: cx(cl['pagination__page-input__input']) }}
             aria-label={`Current page: ${pageIndexIndicator}`}
             value={pageIndexIndicator}
             max={table.pageCount}
-            onChange={(event) => setPageIndexIndicator(Number.parseInt(event.target.value))}
-            onBlur={() => {
-              if(pageIndexIndicator > 0 && pageIndexIndicator <= table.pageCount){
-                table.gotoPage(pageIndexIndicator - 1);
-              } else {
-                table.gotoPage(table.state.pageIndex);
-                setPageIndexIndicator(table.state.pageIndex + 1);
+            onChange={(event) => { setPageIndexIndicator(Number.parseInt(event.target.value)); }}
+            onBlur={() => { updatePage(); }}
+            onKeyDown={event => {
+              if (event.key === 'Enter') {
+                updatePage();
               }
             }}
           />


### PR DESCRIPTION
- In browsers that don't support `field-sizing`, the text input for entering page numbers was sized too large
- Allow hitting "Enter" to trigger the page change
- Handle some edge cases, like entering empty input (this resulted in NaN which wasn't handled)