### PR TITLE
Render `DialogModal` inside of a portal

### DIFF
--- a/src/components/containers/Dialog/Dialog.module.scss
+++ b/src/components/containers/Dialog/Dialog.module.scss
@@ -16,11 +16,6 @@
     
     overflow: hidden;
     
-    // The default `auto` inherits from the parent, which we do not want. In the future if `contain: user-select`
-    // becomes supported, we could use that instead.
-    user-select: text;
-    cursor: default; // Unset in case parent element has a different `cursor`
-    
     margin: 0;
     padding: 0; // Do not apply padding on the outermost container (do it on the lower level elements instead)
     

--- a/src/components/overlays/DialogModal/DialogModal.module.scss
+++ b/src/components/overlays/DialogModal/DialogModal.module.scss
@@ -152,6 +152,14 @@
     }
     
     
+    // NOTE: added a workaround to fix the following inheritance issues, by using a portal to render modals 
+    // 
+    // The default `auto` inherits from the parent, which we do not want. In the future if `contain: user-select`
+    // becomes supported, we could use that instead.
+    //user-select: text;
+    //cursor: default; // Unset in case parent element has a different `cursor`
+    
+    
     //
     // Display variants
     //

--- a/src/components/util/overlays/modal/ModalProvider.tsx
+++ b/src/components/util/overlays/modal/ModalProvider.tsx
@@ -3,6 +3,7 @@
 |* the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react';
+import { createPortal } from 'react-dom';
 
 import { useDelayedUnmount } from '../../../../util/hooks/useDelayedUnmount.ts';
 import { useModalDialogTracker } from '../TopLayerManager.tsx';
@@ -84,7 +85,7 @@ export const ModalProvider = Object.assign(
     
     return (
       <>
-        {shouldMount && dialog(dialogProps)}
+        {shouldMount && createPortal(dialog(dialogProps), document.body)}
         {typeof children === 'function' ? children(modalRef) : children}
       </>
     );

--- a/src/styling/global/reset.scss
+++ b/src/styling/global/reset.scss
@@ -105,9 +105,12 @@
     dialog {
       // Issue: if the parent has `user-select: none` (e.g. button), then the dialog will inherit this by default.
       // In the future, if `contain: user-select` is implemented, we could use that instead.
-      user-select: text;
       &::backdrop {
         user-select: none; // Without this, clicking on the backdrop selects the dialog text in Firefox
+      }
+      // Note: doing this on the parent `dialog` doesn't seem to work in Chrome, the `::backdrop` takes precedence
+      > * {
+        user-select: text;
       }
       
       // Do not position absolutely by default (make that an opt in for modal dialogs only)


### PR DESCRIPTION
Currently `<dialog>` modal elements are rendered in place, and then rendered in the top layer by the browser. This has the issue that the `<dialog>` inherits styling from the ancestor elements. This causes some issues, for example the following:

Resolves #308
Resolves #330
Resolves #339 

Once `@scope` is supported in Firefox, we can solve this just by isolating the styling better. Until then, a portal solves it as well.