### PR TITLE
Add a 1px padding to table cells, as a workaround for browser rounding issues

### DIFF
--- a/src/components/tables/DataTable/table/DataTable.module.scss
+++ b/src/components/tables/DataTable/table/DataTable.module.scss
@@ -33,6 +33,8 @@
           overflow: hidden;
           display: flex;
           
+          padding: 1px; // Add a 1px padding, as a workaround for browser rounding issues (see also #358 on GitHub)
+          
           > * {
             min-inline-size: 0;
           }


### PR DESCRIPTION
Resolves #358 