### PR TITLE
PageLayout variations

### DIFF
--- a/src/layouts/AppLayout/AppLayout.stories.tsx
+++ b/src/layouts/AppLayout/AppLayout.stories.tsx
@@ -8,23 +8,25 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { DummyBkLinkUnstyled, DummyBkLinkWithNotify } from '../../util/storybook/StorybookLink.tsx';
 
 import { notify } from '../../components/overlays/ToastProvider/ToastProvider.tsx';
-import { OverflowTester } from '../../util/storybook/OverflowTester.tsx';
 import { Button } from '../../components/actions/Button/Button.tsx';
-import { Panel } from '../../components/containers/Panel/Panel.tsx';
 import { DialogModal } from '../../components/overlays/DialogModal/DialogModal.tsx';
-
-import { Header } from './Header/Header.tsx';
-import { Sidebar } from './Sidebar/Sidebar.tsx';
 import { FortanixLogo } from '../../fortanix/FortanixLogo/FortanixLogo.tsx';
-import { Nav } from './Nav/Nav.tsx';
+import { LoremIpsum } from '../../util/storybook/LoremIpsum.tsx';
+import { OverflowTester } from '../../util/storybook/OverflowTester.tsx';
+import { Panel } from '../../components/containers/Panel/Panel.tsx';
+import { Select } from '../../components/forms/controls/Select/Select.tsx';
+import { Tag } from '../../components/text/Tag/Tag.tsx';
+
+import { AppLayout } from './AppLayout.tsx';
+import { Breadcrumbs } from './Breadcrumbs/Breadcrumbs.tsx';
+import { Header } from './Header/Header.tsx';
 import { UserMenu } from './Header/UserMenu.tsx';
 import { SolutionSelector } from './Header/SolutionSelector.tsx';
 import { AccountSelector } from './Header/AccountSelector.tsx';
 import { SysadminSwitcher } from './Header/SysadminSwitcher.tsx';
-import { Breadcrumbs } from './Breadcrumbs/Breadcrumbs.tsx';
-import { AppLayout } from './AppLayout.tsx';
-import { Select } from '../../components/forms/controls/Select/Select.tsx';
-import { Tag } from '../../components/text/Tag/Tag.tsx';
+import { Nav } from './Nav/Nav.tsx';
+import { PageHeader } from './PageHeader/PageHeader.tsx';
+import { Sidebar } from './Sidebar/Sidebar.tsx';
 
 
 type AppLayoutArgs = React.ComponentProps<typeof AppLayout>;
@@ -147,6 +149,23 @@ const content1 = (
   </AppLayout.Content>
 );
 
+const contentWithPageHeader = (
+  <AppLayout.Content>
+    <Breadcrumbs>
+      <Breadcrumbs.Item Link={DummyBkLinkWithNotify} href="/" label="Fortanix Armor"/>
+      <Breadcrumbs.Item Link={DummyBkLinkWithNotify} href="/" label="Dashboard" active/>
+    </Breadcrumbs>
+    <PageHeader title="Page Title">
+      <Button kind="tertiary">Tertiary Button</Button>
+      <Button kind="secondary">Secondary Button</Button>
+      <Button kind="primary">Primary Button</Button>
+    </PageHeader>
+    <Panel>
+      <p>Content Area</p>
+    </Panel>
+  </AppLayout.Content>
+);
+
 const footer1 = (
   <AppLayout.Footer>
     <span className="version">Version: 1.2.2343</span>
@@ -160,6 +179,19 @@ export const AppLayoutStandard: Story = {
         {header1}
         {sidebar1}
         {content1}
+        {footer1}
+      </>
+    ),
+  },
+};
+
+export const AppLayoutPage: Story = {
+  args: {
+    children: (
+      <>
+        {header1}
+        {sidebar1}
+        {contentWithPageHeader}
         {footer1}
       </>
     ),

--- a/src/layouts/AppLayout/PageHeader/PageHeader.module.scss
+++ b/src/layouts/AppLayout/PageHeader/PageHeader.module.scss
@@ -1,0 +1,23 @@
+/* Copyright (c) Fortanix, Inc.
+|* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of
+|* the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@use '../../../styling/defs.scss' as bk;
+
+@layer baklava.components {
+  .bk-page-header {
+    @include bk.component-base(bk-page-header);
+    
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    padding: bk.$spacing-7 0;
+    
+    .bk-page-header__actions {
+      display: flex;
+      flex-direction: row;
+      gap: bk.$spacing-7;
+    }
+  }
+}

--- a/src/layouts/AppLayout/PageHeader/PageHeader.stories.tsx
+++ b/src/layouts/AppLayout/PageHeader/PageHeader.stories.tsx
@@ -1,0 +1,50 @@
+/* Copyright (c) Fortanix, Inc.
+|* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of
+|* the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from '../../../components/actions/Button/Button.tsx';
+
+import { PageHeader } from './PageHeader.tsx';
+
+
+type PageHeaderArgs = React.ComponentProps<typeof PageHeader>;
+type Story = StoryObj<PageHeaderArgs>;
+
+const exampleActions1 = (
+  <>
+    <Button kind="tertiary">Tertiary Button</Button>
+    <Button kind="secondary">Secondary Button</Button>
+    <Button kind="primary">Primary Button</Button>
+  </>
+);
+
+export default {
+  component: PageHeader,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {},
+  args: {
+    children: exampleActions1,
+  },
+  render: (args) => (
+  <PageHeader
+    {...args}
+    // dummy style to easily see the gap between elements
+    style={{
+      minWidth: 800,
+      border: '1px solid white',
+    }}
+  />
+),
+} satisfies Meta<PageHeaderArgs>;
+
+export const PageHeaderStandard: Story = {
+  args: {
+    title: 'Page Title',
+  }
+};

--- a/src/layouts/AppLayout/PageHeader/PageHeader.tsx
+++ b/src/layouts/AppLayout/PageHeader/PageHeader.tsx
@@ -1,0 +1,53 @@
+/* Copyright (c) Fortanix, Inc.
+|* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of
+|* the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react';
+import { classNames as cx, type ComponentProps } from '../../../util/componentUtil.ts';
+
+import { H3 } from '../../../typography/Heading/Heading.tsx';
+
+import cl from './PageHeader.module.scss';
+
+
+export { cl as PageHeaderClassNames };
+
+
+type PageHeaderProps = React.PropsWithChildren<ComponentProps<'header'> & {
+  /** Whether this component should be unstyled. */
+  unstyled?: undefined | boolean,
+  
+  /** A page title to be displayed on the left. */
+  title?: undefined | string,
+}>;
+
+/**
+ * A page header with a title and action buttons
+ */
+export const PageHeader = Object.assign(
+  (props: PageHeaderProps) => {
+    const { children, unstyled = false, title, ...propsRest } = props;
+    
+    return (
+      <header
+        {...propsRest}
+        className={cx(
+          'bk',
+          { [cl['bk-page-header']]: !unstyled },
+          propsRest.className,
+        )}
+      >
+        {title && (
+          <H3>{title}</H3>
+        )}
+        <div className={cx(
+          'bk',
+          { [cl['bk-page-header__actions']]: !unstyled },
+        )}>
+          {children}
+        </div>
+      </header>
+    );
+  },
+  {},
+);


### PR DESCRIPTION
Added individual components directly to the AppLayout stories because it made more sense to visualize them.

Includes:
- `PageHeader`, with a `title` and `children` with action buttons on the right

TODO:
- other variations