### PR TITLE
`AppLayout`: set the header to have a higher `z-index` than the sidebar

### DIFF
--- a/src/layouts/AppLayout/AppLayout.module.scss
+++ b/src/layouts/AppLayout/AppLayout.module.scss
@@ -71,7 +71,11 @@
       
       position: sticky;
       inset-block-start: 0;
-      z-index: 1; // Higher than content
+      
+      // Necessary despite the `sticky`, because the page content is a container, which generates a stacking context:
+      // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context
+      // Should be higher than the sidebar (which has `z-index: 1`), so that it remains under the header during scroll.
+      z-index: 2;
       
       display: grid;
       grid:
@@ -93,7 +97,10 @@
     
     > [slot='sidebar'] {
       container: bk-app-layout__sidebar / inline-size;
-      z-index: 1; // E.g. in case the content overflows over the sidebar
+      
+      // Set a z-index higher than the content, so that overflow from the content (e.g. in case of flex row-reverse)
+      // does not overlay the sidebar. Should be lower than the header since the sidebar should scroll "underneath" it.
+      z-index: 1;
       
       padding-block-end: bk.$spacing-8; // Some padding (e.g. for if the sidebar is larger than the viewport height)
       background: bk.$theme-side-nav-background-default;

--- a/src/layouts/AppLayout/Header/Header.module.scss
+++ b/src/layouts/AppLayout/Header/Header.module.scss
@@ -10,10 +10,6 @@
     
     --header-height: var(--bk-app-layout-header-height);
     
-    // Necessary despite the `sticky`, because the page content is a container, which generates a stacking context:
-    // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context
-    z-index: 1;
-    
     block-size: var(--header-height);
     padding-inline: bk.$spacing-5;
     padding-block: bk.$spacing-3;


### PR DESCRIPTION
Fixes an issue where the sidebar would scroll over the header on scroll.