### PR TITLE
(#366) Fix table cell alignment

### DIFF
--- a/src/components/tables/DataTable/DataTableEager.stories.tsx
+++ b/src/components/tables/DataTable/DataTableEager.stories.tsx
@@ -5,6 +5,9 @@
 import { differenceInDays } from 'date-fns';
 import * as React from 'react';
 
+import type { Meta, StoryObj } from '@storybook/react';
+import { LoremIpsum } from '../../../util/storybook/LoremIpsum.tsx';
+
 import { useEffectAsync } from '../../../util/reactUtil.ts';
 import { delay } from '../util/async_util.ts';
 import { type User, generateData } from '../util/generateData.ts';
@@ -55,6 +58,15 @@ const columns = [
     disableSortBy: false,
     sortType: sortDateTime,
     disableGlobalFilter: false,
+    className: 'user-table__column',
+  },
+  {
+    id: 'comments',
+    // Simulate a mix of small height and long height cells
+    accessor: (_user: User, index: number) => index % 2 === 0 ? <LoremIpsum short/> : null,
+    Header: 'Comments',
+    disableSortBy: true,
+    disableGlobalFilter: true,
     className: 'user-table__column',
   },
 ];

--- a/src/components/tables/DataTable/plugins/useRowSelectColumn.module.scss
+++ b/src/components/tables/DataTable/plugins/useRowSelectColumn.module.scss
@@ -5,10 +5,9 @@
 @use '../../../../styling/defs.scss' as bk;
 
 @layer baklava.components {
-  .bk-data-table-row-select {
+  th.bk-data-table-row-select {
     @include bk.component-base(bk-data-table-row-select);
     
-    inline-size: bk.$spacing-11;
-    max-inline-size: bk.$spacing-11;
+    inline-size: 8ch;
   }
 }

--- a/src/components/tables/DataTable/table/DataTable.module.scss
+++ b/src/components/tables/DataTable/table/DataTable.module.scss
@@ -24,16 +24,23 @@
       }
       
       td {
+        // Align all table cells to the top, to prevent one large item in a cell from shifting all the other content
+        // down.
+        vertical-align: top;
+        
         overflow: hidden;
         padding: bk.$spacing-5 bk.$spacing-2;
         
         // Note: need a wrapper div for this because setting a different `display` on a `<td>` will break the table
         .bk-data-table__text-cell {
-          // The following are needed for `<TextLine>` to work
+          // Note: for `<TextLine>` to work as a child of this element, we need `display: flex` and `overflow: hidden`
           overflow: hidden;
-          display: flex;
           
+          min-block-size: 1lh;
           padding: 1px; // Add a 1px padding, as a workaround for browser rounding issues (see also #358 on GitHub)
+          
+          display: flex;
+          align-items: center;
           
           > * {
             min-inline-size: 0;


### PR DESCRIPTION
Resolves #366.

The default table cell alignment did not work great when there was a checkbox or multi-line content. I changed it so that all table cell content is top-aligned, and content like checkboxes can be aligned by making the height roughly 1 line height.

<img width="1431" alt="Screenshot 2025-06-16 at 17 37 14" src="https://github.com/user-attachments/assets/a9b05e72-fc90-4a2f-99dd-ea8aadd7c75c" />