### PR TITLE
fix: show not-allowed cursor on disabled radio (#382)

### DIFF
--- a/src/components/forms/controls/Radio/Radio.module.scss
+++ b/src/components/forms/controls/Radio/Radio.module.scss
@@ -40,6 +40,7 @@
     &:disabled {
       border: 1px solid bk.$theme-radio-disabled;
       background-color: transparent;
+      cursor: not-allowed;
       
       &:checked {
         border: 2px solid bk.$theme-radio-non-active;


### PR DESCRIPTION
 ### What’s fixed
Fixes #382 — Added `cursor: not-allowed` to `.bk-radio:disabled` to ensure the correct cursor is shown when the radio button is disabled.

### What’s changed
- Added one line to the SCSS file:
  ```scss
  &:disabled {
    cursor: not-allowed;
    ...
  }
  
  
  
  **Verified manually in Storybook that the disabled radio shows not-allowed cursor on hover.**