### PR TITLE
`Switch` – Make radial-gradient() antialiasing independent of device pixel ratio

### DIFF
--- a/src/components/forms/controls/Switch/Switch.module.scss
+++ b/src/components/forms/controls/Switch/Switch.module.scss
@@ -34,17 +34,17 @@
     // Render the track (using circles to emulate a capsule shape)
     // Note: add `1px` difference between the stops so that we have a subtle antialiasing
     $col: var(--bk-switch-track-color);
-    $a: 1px; // Antialias
+    $a: calc(1px / var(--bk-device-pixel-ratio, 1)); // Antialias
     background:
       // https://css-tricks.com/drawing-images-with-css-gradients
       linear-gradient($col, $col) 50% 50% / calc(var(--w) - var(--h)) calc(var(--h)) no-repeat,
-      radial-gradient(circle at var(--r), $col calc(var(--h) / 2 - ($a/2)), transparent calc(var(--h) / 2 + ($a/2))),
-      radial-gradient(circle at calc(100% - var(--r)), $col calc(var(--h) / 2 - ($a/2)), transparent calc(var(--h) / 2 + ($a/2)));
+      radial-gradient(circle at var(--r), $col calc(var(--h) / 2 - $a), transparent calc(var(--h) / 2 + $a)),
+      radial-gradient(circle at calc(100% - var(--r)), $col calc(var(--h) / 2 - $a), transparent calc(var(--h) / 2 + $a));
     // Render the thumb
     border-image:
       radial-gradient(circle at var(--bk-switch-pos),
-        var(--bk-switch-thumb-color) calc(var(--r) - ($a/2)),
-        transparent calc(var(--r) + ($a/2))
+        var(--bk-switch-thumb-color) calc(var(--r) - $a),
+        transparent calc(var(--r) + $a)
       ) fill 0 / 1 / 0;
     
     &:checked {

--- a/src/context/BaklavaProvider.tsx
+++ b/src/context/BaklavaProvider.tsx
@@ -27,7 +27,31 @@ if (!addedTestNotify && import.meta.env.MODE === 'development') {
 }
 */
 
+
+/**
+ * Track the current device pixel ratio and store it as a CSS custom property (for use in styling).
+ * Inspired by: https://frontendmasters.com/blog/obsessing-over-smooth-radial-gradient-disc-edges
+ */
+const useDevicePixelRatioTracker = () => {
+  const [devicePixelRatio, setDevicePixelRatio] = React.useState<number>(window.devicePixelRatio);
+  
+  React.useEffect(() => {
+    document.body.style.setProperty('--bk-device-pixel-ratio', String(devicePixelRatio));
+    
+    const controller = new AbortController();
+    window.matchMedia(`(resolution: ${window.devicePixelRatio}x)`)
+      .addEventListener('change',
+        () => { setDevicePixelRatio(window.devicePixelRatio); },
+        { signal: controller.signal },
+      );
+    
+    return () => { controller.abort(); };
+  }, [devicePixelRatio]);
+};
+
 export const BaklavaProvider = (props: React.PropsWithChildren) => {
+  useDevicePixelRatioTracker();
+  
   return (
     <TopLayerManager>
       <ToastProvider global>


### PR DESCRIPTION
Update the `Switch` component to use slightly smarter antialiasing for CSS `radial-gradient()`. To make `radial-gradient()` smooth in CSS we need a small bit of antialiasing, however the amount of antialiasing we need depends on the current screen's device pixel width (including the current zoom factor).

Before, we always just used 1px. This PR updates the logic by using `window.devicePixelRatio`, as described in [this article](https://frontendmasters.com/blog/obsessing-over-smooth-radial-gradient-disc-edges).