### PR TITLE
`Tabs` – Prevent tab hover state from causing layout shift

### DIFF
--- a/src/components/navigations/Tabs/Tabs.module.scss
+++ b/src/components/navigations/Tabs/Tabs.module.scss
@@ -14,13 +14,21 @@
       border-block-end: 1px solid #{bk.$theme-tab-rule-default};
       
       .bk-tabs__switcher__tab {
+        cursor: pointer;
         position: relative;
         user-select: none;
+        
         padding: bk.$spacing-3 bk.$spacing-8;
+        
+        display: grid;
+        grid-template-areas: stack;
+        > * {
+          grid-area: stack;
+        }
+        
         color: #{bk.$theme-tab-text-default};
         @include bk.font(bk.$font-family-body, bk.$font-weight-semibold, bk.$font-size-m);
         text-transform: uppercase;
-        cursor: pointer;
         white-space: nowrap;
         
         // The active tab underline (zero height by default)
@@ -32,6 +40,11 @@
           inset-block-end: 0;
           block-size: 0;
           transition: .3s;
+        }
+        
+        > .bk-tabs__switcher__tab__hover-placeholder {
+          visibility: hidden;
+          font-weight: bk.$font-weight-bold;
         }
         
         &:is(:hover, :global(.pseudo-hover)) {

--- a/src/components/navigations/Tabs/Tabs.tsx
+++ b/src/components/navigations/Tabs/Tabs.tsx
@@ -104,7 +104,8 @@ export const Tabs = (props: TabsProps) => {
               className={cx(cl['bk-tabs__switcher__tab'],tab.props.className)}
               onClick={() => { onSwitch(tab.props.tabKey); }} // FIXME: add a Button and use that instead
             >
-              {tab.props.title}
+              <span>{tab.props.title}</span>
+              <span className={cx(cl['bk-tabs__switcher__tab__hover-placeholder'])}>{tab.props.title}</span>
             </li>
           )
         })}

--- a/src/components/navigations/Tabs/Tabs.tsx
+++ b/src/components/navigations/Tabs/Tabs.tsx
@@ -105,7 +105,8 @@ export const Tabs = (props: TabsProps) => {
               onClick={() => { onSwitch(tab.props.tabKey); }} // FIXME: add a Button and use that instead
             >
               <span>{tab.props.title}</span>
-              <span className={cx(cl['bk-tabs__switcher__tab__hover-placeholder'])}>{tab.props.title}</span>
+              {/* Hidden duplicated title, used to prevent layout shifts on hover. */}
+              <span aria-hidden className={cx(cl['bk-tabs__switcher__tab__hover-placeholder'])}>{tab.props.title}</span>
             </li>
           )
         })}


### PR DESCRIPTION
Before, hovering over a tab (which applies a bold font weight) would cause a layout shift due to the increased width of the bold text. In this PR this is resolved by adding a hidden placeholder for the hover style so that the tab already takes up the width it would when in hover state. It uses CSS grid to stack the hidden and visible text in the same grid cell so that the browser will take the width of the hidden text into account.