### PR TITLE
Update Disclosure to work better in Firefox/Safari + Prose tweaks.

### DIFF
--- a/src/components/containers/Banner/Banner.stories.tsx
+++ b/src/components/containers/Banner/Banner.stories.tsx
@@ -50,11 +50,11 @@ const BannerControlled = (props: React.ComponentProps<typeof Banner>) => {
 export default {
   component: Banner,
   parameters: {
-    layout: 'padded',
+    layout: 'centered',
     design: { type: 'figma', url: 'https://www.figma.com/design/ymWCnsGfIsC2zCz17Ur11Z/Design-System-UX?node-id=4573-147249&m=dev' },
   },
   decorators: [
-    Story => <LayoutDecorator size="large" /*resize="inline"*/><Story/></LayoutDecorator>,
+    Story => <LayoutDecorator size="large" resize="inline"><Story/></LayoutDecorator>,
   ],
   tags: ['autodocs'],
   args: {

--- a/src/components/containers/Dialog/Dialog.module.scss
+++ b/src/components/containers/Dialog/Dialog.module.scss
@@ -68,6 +68,7 @@
     }
     
     .bk-dialog__content__icon-aside {
+      flex-shrink: 0;
       align-self: flex-start;
       font-size: 1.4em;
       

--- a/src/components/containers/Dialog/Dialog.stories.tsx
+++ b/src/components/containers/Dialog/Dialog.stories.tsx
@@ -24,7 +24,7 @@ export default {
   tags: ['autodocs'],
   component: Dialog,
   parameters: {
-    layout: 'padded',
+    layout: 'centered',
   },
   decorators: [
     Story => <LayoutDecorator size="large" style={{ maxHeight: '20lh' }}><Story/></LayoutDecorator>,

--- a/src/components/containers/Disclosure/Disclosure.module.scss
+++ b/src/components/containers/Disclosure/Disclosure.module.scss
@@ -23,7 +23,7 @@
     --bk-disclosure-border-radius-top: #{bk.$radius-3};
     --bk-disclosure-border-radius-bottom: #{bk.$radius-3};
     --bk-disclosure-padding-inline: #{bk.$spacing-4};
-    --bk-disclosure-padding-block: #{bk.rem-from-px(14)}; // FIXME: does not correspond to an existing token
+    --bk-disclosure-padding-block: #{bk.$spacing-3};
     
     overflow: hidden;
     
@@ -91,8 +91,8 @@
     // visible (due to `content-visibility: hidden` still taking up space). So we use this as scroller and for spacing.
     .bk-disclosure__content {
       margin-block:
-        bk.$spacing-8
-        calc(bk.$spacing-8 - var(--bk-disclosure-padding-block)); // Total should equal `bk.$spacing-8`
+        bk.$spacing-3
+        calc(bk.$spacing-6 - var(--bk-disclosure-padding-block)); // Total should equal `bk.$spacing-6`
       overflow: hidden;
     }
     // Make the content scrollable when the content is open

--- a/src/components/containers/Disclosure/Disclosure.module.scss
+++ b/src/components/containers/Disclosure/Disclosure.module.scss
@@ -54,7 +54,7 @@
       
       display: flex;
       align-items: center;
-      gap: bk.$spacing-9;
+      gap: bk.$spacing-3;
       
       line-height: bk.$line-height-m;
       
@@ -120,38 +120,6 @@
     }
     &[open]::details-content {
       block-size: auto;
-    }
-    
-    // Fallback styling for browsers that don't support `::details-content` and `interpolate-size`
-    @supports not (selector(::details-content) and (interpolate-size: allow-keywords)) {
-      // Fix padding
-      .bk-disclosure__content {
-        // In case of overflow, since we don't the flex parent, the margin bottom here won't work.
-        // Move it to `details[open]` instead.
-        margin-block-end: 0;
-      }
-      &[open] { padding-block-end: bk.$spacing-8; }
-      
-      // Fix scrolling
-      // stylelint-disable-next-line no-duplicate-selectors
-      .bk-disclosure__content {
-        // It seems there is no easy way to make this element scrollable with `block-size: auto` (and setting the height
-        // on the `<details>` instead), because without `::details-content` there is no way to make the details content
-        // a flex container.
-        // What does work is to set an explicit block-size on the `.bk-disclosure__content`.
-        //block-size: 20rem; // This works
-        
-        // We can use a variable for the `<details>` height and then calculate the height of the content box.
-        --summary-block-size: calc(var(--bk-disclosure-padding-block) + 1.6rem);
-        --padding-block: calc(2 * #{bk.$spacing-8});
-        max-block-size: calc(var(--bk-disclosure-max-height) - var(--summary-block-size) - var(--padding-block));
-      }
-      &[open] .bk-disclosure__content {
-        animation: none;
-        // Apply the `overflow-y: auto` immediately, since there is no animation
-        // stylelint-disable-next-line declaration-property-value-disallowed-list
-        overflow-y: auto;
-      }
     }
   }
 }

--- a/src/fortanix/FortanixLogo/FortanixLogo.stories.tsx
+++ b/src/fortanix/FortanixLogo/FortanixLogo.stories.tsx
@@ -21,7 +21,7 @@ export default {
   },
   tags: ['autodocs'],
   decorators: [
-    Story => <LayoutDecorator size="medium"><p style={{ fontSize: '3rem' }}><Story/></p></LayoutDecorator>,
+    Story => <div style={{ fontSize: '3rem' }}><Story/></div>,
   ],
   argTypes: {},
   render: (args) => <FortanixLogo {...args} />,
@@ -34,11 +34,11 @@ export const FortanixLogoStandard: Story = {};
 export const FortanixLogoInText: Story = {
   decorators: [
     Story => (
-      <p style={{ '--font-size': '1.2rem', fontSize: 'var(--font-size)' }}>
+      <div style={{ '--font-size': '1.2rem', fontSize: 'var(--font-size)' }}>
         <LoremIpsum style={{ fontSize: 'var(--font-size)' }}/>
         <Story/>
         <LoremIpsum style={{ fontSize: 'var(--font-size)' }}/>
-      </p>
+      </div>
     ),
   ],
 };

--- a/src/fortanix/FortanixLogo/FortanixLogo.stories.tsx
+++ b/src/fortanix/FortanixLogo/FortanixLogo.stories.tsx
@@ -20,30 +20,32 @@ export default {
     layout: 'centered',
   },
   tags: ['autodocs'],
-  decorators: [
-    Story => <div style={{ fontSize: '3rem' }}><Story/></div>,
-  ],
   argTypes: {},
   render: (args) => <FortanixLogo {...args} />,
 } satisfies Meta<FortanixLogoArgs>;
 
 
-export const FortanixLogoStandard: Story = {};
+export const FortanixLogoStandard: Story = {
+  decorators: [Story => <div style={{ fontSize: '3rem' }}><Story/></div>],
+};
 
 /** The logo scales with the font size. */
 export const FortanixLogoInText: Story = {
   decorators: [
     Story => (
-      <div style={{ '--font-size': '1.2rem', fontSize: 'var(--font-size)' }}>
-        <LoremIpsum style={{ fontSize: 'var(--font-size)' }}/>
-        <Story/>
-        <LoremIpsum style={{ fontSize: 'var(--font-size)' }}/>
-      </div>
+      <LayoutDecorator size="large">
+        <div style={{ '--font-size': '1.2rem', fontSize: 'var(--font-size)' }}>
+          <LoremIpsum style={{ fontSize: 'var(--font-size)' }}/>
+          <Story/>
+          <LoremIpsum style={{ fontSize: 'var(--font-size)' }}/>
+        </div>
+      </LayoutDecorator>
     ),
   ],
 };
 
 export const FortanixLogoWithSubtitle: Story = {
+  decorators: [Story => <div style={{ fontSize: '3rem' }}><Story/></div>],
   args: {
     subtitle: 'Data Security Manager',
     subtitleTrademark: true,

--- a/src/typography/Prose/Prose.mixins.scss
+++ b/src/typography/Prose/Prose.mixins.scss
@@ -7,234 +7,252 @@
 
 // Inheritable styles
 @mixin prose-root {
-  --bk-prose-line-height: 1.6;
-  --bk-body-block-spacing: 0.8lh;
-  
-  font-family: var(--bk-font-family-body);
-  font-weight: 400;
-  font-size: 1rem;
+  @layer prose-root {
+    // Capture the size of `1lh` at the root level (note: requires an `@property`)
+    // Reference: https://codepen.io/maikelkrause/pen/PwPRQPK
+    --bk-prose-base-lh: 1lh;
+    --bk-prose-block-spacing: calc(var(--bk-prose-base-lh) * 0.8);
+    --bk-prose-line-height: 1.6;
+    
+    font-family: var(--bk-font-family-body);
+    font-weight: 400;
+    //font-size: 1rem; // Allow the parent to control the base font size for this `Prose` element
+  }
 }
 
 @mixin prose {
-  line-height: var(--bk-prose-line-height);
-  overflow-wrap: break-word; // Prevent long words causing overflow
-  text-wrap: pretty; // Favor better typography for text wrapping (e.g. prevent orphans)
-  hyphens: auto;
-  
-  
-  //
-  // Elements
-  //
-  
-  // Note: in order to not break the workaround for Firefox, we should not use a descendent selector in any of these.
-  // For all selectors, use `&:is(X)` so that we apply the condition to the current context and not "any descendent".
-  // Use `> X:not(.bk)` if you need to select a child element (using `:not(.bk)` to ensure it's not a component).
-  
-  &:is(h1) { @include typography.h1; }
-  &:is(h2) { @include typography.h2; }
-  &:is(h3) { @include typography.h3; }
-  &:is(h4) { @include typography.h4; }
-  &:is(h5) { @include typography.h5; }
-  &:is(h6) { @include typography.h6; }
-  
-  &:is(i, em) { font-style: italic; }
-  &:is(b, strong, th) { font-weight: bk.$font-weight-semibold; }
-  &:is(u) { text-decoration: underline; }
-  
-  &:is(p) {
-    margin-block-start: var(--bk-body-block-spacing);
-    overflow-wrap: break-word; // Allow breaking mid-word if they would otherwise cause overflow
-  }
-  
-  &:is(ul, ol, dl) {
-    --list-indent: 3ch;
+  @layer prose-elements {
+    line-height: var(--bk-prose-line-height);
+    overflow-wrap: break-word; // Prevent long words causing overflow
+    text-wrap: pretty; // Favor better typography for text wrapping (e.g. prevent orphans)
+    hyphens: auto;
     
-    display: block;
-    margin-block-start: calc(var(--bk-body-block-spacing) / 2);
-    padding-inline-start: var(--list-indent); // Make space for `::marker`
     
-    > li:not(.bk) {
-      margin-block-start: calc(var(--bk-body-block-spacing) / 4); // Spacing between items
+    //
+    // Elements
+    //
+    
+    // Note: in order to not break the workaround for Firefox, we should not use a descendent selector in any of these.
+    // For all selectors, use `&:is(X)`, so that we apply the condition to the current context and not "any descendent".
+    // Use `> X:not(.bk)` if you need to select a child element (using `:not(.bk)` to ensure it's not a component).
+    
+    &:is(h1) { @include typography.h1; }
+    &:is(h2) { @include typography.h2; }
+    &:is(h3) { @include typography.h3; }
+    &:is(h4) { @include typography.h4; }
+    &:is(h5) { @include typography.h5; }
+    &:is(h6) { @include typography.h6; }
+    
+    &:is(i, em) { font-style: italic; }
+    &:is(b, strong, th) { font-weight: bk.$font-weight-semibold; }
+    &:is(u) { text-decoration: underline; }
+    
+    &:is(p) {
+      margin-block-start: var(--bk-prose-block-spacing);
+      overflow-wrap: break-word; // Allow breaking mid-word if they would otherwise cause overflow
+    }
+    
+    &:is(ul, ol, dl) {
+      --list-indent: 3ch;
       
-      // Nested lists
-      > :is(ul, ol, dl):not(.bk) {
-        margin-block-start: calc(var(--bk-body-block-spacing) / 3);
+      display: block;
+      margin-block-start: calc(var(--bk-prose-block-spacing) / 2);
+      padding-inline-start: var(--list-indent); // Make space for `::marker`
+      
+      > li:not(.bk) {
+        margin-block-start: calc(var(--bk-prose-block-spacing) / 4); // Spacing between items
+        
+        // Nested lists
+        > :is(ul, ol, dl):not(.bk) {
+          margin-block-start: calc(var(--bk-prose-block-spacing) / 3);
+        }
       }
     }
-  }
-  &:is(ul) {
-    // Note: do not use list-style: none, this causes accessibility issues:
-    // https://css-tricks.com/newer-things-to-know-about-good-ol-html-lists/#aa-newer-accessibility-concerns-with-lists
-    list-style: disc outside;
-    
-    > li:not(.bk)::marker {
-      // Override the marker style so we customize the gap size
-      // https://css-tricks.com/everything-you-need-to-know-about-the-gap-after-the-list-marker
-      content: '\2022\00A0\00A0';
-      margin: 0; // Margin and padding are not supported by `::marker` currently
-      font-size: 1.2em;
-      line-height: 1;
+    &:is(ul) {
+      // Note: do not use list-style: none, this causes accessibility issues:
+      // https://css-tricks.com/newer-things-to-know-about-good-ol-html-lists/#aa-newer-accessibility-concerns-with-lists
+      list-style: disc outside;
+      
+      > li:not(.bk)::marker {
+        // Override the marker style so we customize the gap size
+        // https://css-tricks.com/everything-you-need-to-know-about-the-gap-after-the-list-marker
+        content: '\2022\00A0\00A0';
+        margin: 0; // Margin and padding are not supported by `::marker` currently
+        font-size: 1.2em;
+        line-height: 1;
+      }
     }
-  }
-  &:is(ol) {
-    // Note: do not use list-style: none, this causes accessibility issues:
-    // https://css-tricks.com/newer-things-to-know-about-good-ol-html-lists/#aa-newer-accessibility-concerns-with-lists
-    list-style: decimal outside;
-  }
-  
-  &:is(hr) {
-    margin-block: bk.$spacing-4;
-    border: none;
-    border-block-start: bk.rem-from-px(1) solid currentColor;
-  }
-  
-  &:is(blockquote) {
-    border-inline-start: 4px solid #0096bfab;
-    margin: 1.5em 0;
-    padding: 0.5em 1em;
-    font-style: italic;
+    &:is(ol) {
+      // Note: do not use list-style: none, this causes accessibility issues:
+      // https://css-tricks.com/newer-things-to-know-about-good-ol-html-lists/#aa-newer-accessibility-concerns-with-lists
+      list-style: decimal outside;
+    }
     
-    & > footer:not(.bk), & > cite:not(.bk) {
+    &:is(hr) {
+      margin-block: bk.$spacing-4;
+      border: none;
+      border-block-start: bk.rem-from-px(1) solid currentColor;
+    }
+    
+    &:is(blockquote) {
+      border-inline-start: bk.rem-from-px(4) solid #0096bfab;
+      margin: 1.5em 0;
+      padding: 0.5em 1em;
+      font-style: italic;
+      
+      & > footer:not(.bk), & > cite:not(.bk) {
+        font-style: normal;
+      }
+    }
+    
+    &:is(address) {
       font-style: normal;
     }
-  }
-  
-  &:is(address) {
-    font-style: normal;
-  }
-  
-  &:is(table) {
-    inline-size: 100%;
-    border-collapse: collapse;
-    margin-block-start: var(--bk-body-block-spacing);
-    table-layout: fixed;
-  }
-  
-  &:is(th) {
-    padding-inline-start: bk.$spacing-2;
-    padding-block-end: bk.$spacing-1;
-    vertical-align: middle;
-    font-size: bk.$font-size-s;
-    color: bk.$theme-table-text-header-default;
-    text-transform: uppercase;
-    cursor: default;
-  }
-  
-  &:is(td) {
-    vertical-align: top;
-    padding: bk.$spacing-3 bk.$spacing-2;
-  }
-
-  &:is(td, th) {
-    border-block-end: 1px solid bk.$theme-rule-default;
-    overflow: hidden;
-  }
-  
-  // Media
-  
-  &:is(img) {
-    max-inline-size: 100%;
-  }
-  
-  
-  // Interactive elements
-  
-  &:is(a) { @include typography.link; }
-  
-  &:is(label, button, input[type='submit'], input[type='button'], input[type='checkbox']) {
-    cursor: pointer;
-  }
-  
-  /*
-  &:is(button, input, textarea) {
-    transition:
-      background-color 0.1s linear,
-      border-color 0.1s linear,
-      color 0.1s linear,
-      box-shadow 0.1s linear,
-      transform 0.1s ease;
-  }
-  
-  &:is(input:not([type='checkbox'], [type='radio']), select) {
-    display: block;
-  }
-  
-  &:is(input, select, button, textarea) {
-    color: #000000;
-    background-color: #efefef;
-    font-family: inherit;
-    font-size: inherit;
-    margin-inline-end: 6px;
-    margin-block-end: 6px;
-    padding: 10px;
-    border: none;
-    border-radius: 6px;
-    outline: none;
-  }
-  
-  &:is(
-    input:not([type='checkbox']):not([type='radio']),
-    select,
-    button,
-    textarea,
-  ) {
-    -webkit-appearance: none;
-  }
-  
-  &:is(textarea) {
-    margin-inline-end: 0;
-    inline-size: 100%;
-    box-sizing: border-box;
-    resize: vertical;
-  }
-  
-  &:is(button, input[type='submit'], input[type='button']) {
-    padding-inline: 30px;
-  }
-  
-  &:is(button:hover, input[type='submit']:hover, input[type='button']:hover) {
-    background: #dddddd;
-  }
-  
-  &:is(input:disabled, select:disabled, button:disabled, textarea:disabled) {
-    cursor: not-allowed;
-    opacity: .5;
-  }
-  
-  &:is(::-webkit-input-placeholder) {
-    color: #949494;
-  }
-  
-  &:is(::placeholder) {
-    color: #949494;
-  }
-  
-  &:is(code, kbd) {
-    background: light-dark(#ccc, #333);
-    padding: 5px;
-    border-radius: 3px;
-    font-family: var(--bk-font-family-code, monospace);
-  }
-  
-  &:is(pre) {
-    > code:not(.bk) {
-      padding: 10px;
-      display: block;
-      // Note: we don't control the code here, so can't use `useScroller()`. Consumer needs to add the tabindex.
-      // stylelint-disable-next-line declaration-property-value-disallowed-list
-      overflow-x: auto;
+    
+    &:is(table) {
+      inline-size: 100%;
+      border-collapse: collapse;
+      margin-block-start: var(--bk-prose-block-spacing);
+      table-layout: fixed;
     }
+    
+    &:is(th) {
+      cursor: default;
+      padding-inline-start: bk.$spacing-2;
+      padding-block-end: bk.$spacing-1;
+      
+      vertical-align: middle;
+      font-size: bk.$font-size-s;
+      color: bk.$theme-table-text-header-default;
+      text-transform: uppercase;
+    }
+    
+    &:is(td) {
+      vertical-align: top;
+      padding: bk.$spacing-3 bk.$spacing-2;
+    }
+
+    &:is(td, th) {
+      border-block-end: bk.rem-from-px(1) solid bk.$theme-rule-default;
+      overflow: hidden;
+    }
+    
+    // Media
+    
+    &:is(img) {
+      max-inline-size: 100%;
+    }
+    
+    
+    // Interactive elements
+    
+    &:is(a) { @include typography.link; }
+    
+    &:is(label, button, input[type='submit'], input[type='button'], input[type='checkbox']) {
+      cursor: pointer;
+    }
+    
+    /*
+    &:is(button, input, textarea) {
+      transition:
+        background-color 0.1s linear,
+        border-color 0.1s linear,
+        color 0.1s linear,
+        box-shadow 0.1s linear,
+        transform 0.1s ease;
+    }
+    
+    &:is(input:not([type='checkbox'], [type='radio']), select) {
+      display: block;
+    }
+    
+    &:is(input, select, button, textarea) {
+      color: #000000;
+      background-color: #efefef;
+      font-family: inherit;
+      font-size: inherit;
+      margin-inline-end: 6px;
+      margin-block-end: 6px;
+      padding: 10px;
+      border: none;
+      border-radius: 6px;
+      outline: none;
+    }
+    
+    &:is(
+      input:not([type='checkbox']):not([type='radio']),
+      select,
+      button,
+      textarea,
+    ) {
+      -webkit-appearance: none;
+    }
+    
+    &:is(textarea) {
+      margin-inline-end: 0;
+      inline-size: 100%;
+      box-sizing: border-box;
+      resize: vertical;
+    }
+    
+    &:is(button, input[type='submit'], input[type='button']) {
+      padding-inline: 30px;
+    }
+    
+    &:is(button:hover, input[type='submit']:hover, input[type='button']:hover) {
+      background: #dddddd;
+    }
+    
+    &:is(input:disabled, select:disabled, button:disabled, textarea:disabled) {
+      cursor: not-allowed;
+      opacity: .5;
+    }
+    
+    &:is(::-webkit-input-placeholder) {
+      color: #949494;
+    }
+    
+    &:is(::placeholder) {
+      color: #949494;
+    }
+    
+    &:is(code, kbd) {
+      background: light-dark(#ccc, #333);
+      padding: 5px;
+      border-radius: 3px;
+      font-family: var(--bk-font-family-code, monospace);
+    }
+    
+    &:is(pre) {
+      > code:not(.bk) {
+        padding: 10px;
+        display: block;
+        // Note: we don't control the code here, so can't use `useScroller()`. Consumer needs to add the tabindex.
+        // stylelint-disable-next-line declaration-property-value-disallowed-list
+        overflow-x: auto;
+      }
+    }
+    */
   }
-  */
   
-  
-  // XXX replace this with `margin-trim` once that's available
-  & > :nth-child(1 of :not(.bk, [hidden], dialog)) {
-    margin-block-start: 0;
+  // Note: need to give this higher specificity, otherwise this gets overridden by earlier selectors
+  @layer prose-overrides {
+    // XXX replace this with `margin-trim` once that's available
+    & > :nth-child(1 of :not(.bk, [hidden], dialog)) {
+      margin-block-start: 0;
+    }
   }
 }
 
 @mixin styles {
+  @layer prose-root, prose-elements, prose-overrides;
+  
+  @property --bk-prose-base-lh {
+    syntax: '<length>';
+    initial-value: 0;
+    inherits: true;
+  }
+  
   // Do not leak .bk-prose styling into components
   // FIXME: browser support for `@scope` is not quite there yet (but we can't do `@supports at-rule()` yet either)
   // See: https://css-tricks.com/solved-by-css-donuts-scopes

--- a/src/typography/Prose/Prose.module.scss
+++ b/src/typography/Prose/Prose.module.scss
@@ -2,6 +2,7 @@
 |* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of
 |* the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-@use './Prose.mixins.scss' as Prose;
 
-@include Prose.styles;
+// Note: this is already included in main.scss, do not emit it twice
+//@use './Prose.mixins.scss' as Prose;
+//@include Prose.styles;

--- a/src/typography/Prose/Prose.tsx
+++ b/src/typography/Prose/Prose.tsx
@@ -10,21 +10,27 @@ import cl from './Prose.module.scss';
 
 export { cl as ProseClassNames };
 
-export type ProseProps = React.PropsWithChildren<ComponentProps<'article'> & {
+export type ProseProps = ComponentProps<'article'> & {
   /** Whether this component should be unstyled. */
   unstyled?: undefined | boolean,
-}>;
+};
 /**
- * Prose component.
+ * This component is intended for prose: document-style text, with rich styling for paragraphs, headings, lists,
+ * tables, etc. By default in Baklava, all base styles for standard HTML elements are removed. Within a `<Prose>`
+ * element, these styles are reapplied, so that you can use elements like `<p>`, `<ul>`, `<b>`, etc. without any class
+ * names and still get the expected visual styling.
+ * 
+ * Note: any Baklava components nested within a `<Prose>` element will not be affected by these styles.
  */
 export const Prose = ({ unstyled, ...propsRest }: ProseProps) => {
   return (
     <article
       {...propsRest}
-      className={cx({
-        bk: true,
-        'bk-prose': !unstyled,
-      }, propsRest.className)}
+      className={cx(
+        'bk',
+        { 'bk-prose': !unstyled },
+        propsRest.className,
+      )}
     />
   );
 };

--- a/src/util/storybook/LayoutDecorator.module.scss
+++ b/src/util/storybook/LayoutDecorator.module.scss
@@ -14,7 +14,7 @@
     &.util-layout-decorator--large { --util-layout-decorator-size: 100ch; }
     &.util-layout-decorator--x-large { --util-layout-decorator-size: 140ch; }
     
-    inline-size: min(100cqi - 2em, var(--util-layout-decorator-size));
+    inline-size: min(100cqi - 5em, var(--util-layout-decorator-size));
     
     &.util-layout-decorator--resizable {
       padding-block-end: 10px; // Make space for the resize control in the corner

--- a/src/util/storybook/LayoutDecorator.module.scss
+++ b/src/util/storybook/LayoutDecorator.module.scss
@@ -6,15 +6,15 @@
   .util-layout-decorator {
     overflow: hidden; // Note: either `hidden` or `scroll` is required for `resize` to work
     
-    inline-size: -webkit-fill-available;
-    inline-size: stretch; // https://caniuse.com/mdn-css_properties_width_stretch
+    padding: var(--bk-focus-outline-width); // Add some spacing so as not to cut off any focus outlines
     
-    padding: var(--bk-focus-outline-width); // Add some spacing so as not to cut off focus outlines
+    --util-layout-decorator-size: 80ch;
+    &.util-layout-decorator--small { --util-layout-decorator-size: 60ch; }
+    &.util-layout-decorator--medium { --util-layout-decorator-size: 80ch; }
+    &.util-layout-decorator--large { --util-layout-decorator-size: 100ch; }
+    &.util-layout-decorator--x-large { --util-layout-decorator-size: 140ch; }
     
-    &.util-layout-decorator--small { max-inline-size: 60ch; }
-    &.util-layout-decorator--medium { max-inline-size: 80ch; }
-    &.util-layout-decorator--large { max-inline-size: 100ch; }
-    &.util-layout-decorator--x-large { max-inline-size: 140ch; }
+    inline-size: min(100cqi - 2em, var(--util-layout-decorator-size));
     
     &.util-layout-decorator--resizable {
       padding-block-end: 10px; // Make space for the resize control in the corner


### PR DESCRIPTION
Resolves #211 
Resolves #464

This PR:
- Removes the `@support` fallback styles for `Disclosure`. In Firefox and Safari this was causing some issues (see #211). I did some testing on Safari 18.6 and Firefox 142 (with and without the `::details-content` flag enabled), and it turns out that removing the fallback styles seems to work fine for all stories. I may do some more testing in these browsers to see if I can find potential issues, but as far as I cant tell even with lack of `::details-content` support our current styles are gracefully falling back in non-supported browsers.
- Updates `Prose` to implement a "base lh" unit (see #464) so that block margins are independent of the current font size. Also fixes an issue (at least in Firefox) where the `margin-top: 0` override didn't get applied due to a specificity clash.
- Fixes an issue in `Dialog` where the "aside" element would shrink if there isn't enough space. Changed it to never shrink using `flex-shrink: 0`.
- Updates `LayoutDecorator` so that the component stretches to the specified width by default, while still shrinking if there's not enough space in the viewport.