### PR TITLE
(#462) Remove the underline from PageLayout.ScopeSwitcher

### DIFF
--- a/src/layouts/PageLayout/PageLayout.module.scss
+++ b/src/layouts/PageLayout/PageLayout.module.scss
@@ -40,6 +40,10 @@
 
       .bk-page-layout__header__scope-switcher {
         @include typography.h6;
+        
+        > div {
+          border: none;
+        }
       }
     }
   }

--- a/src/layouts/PageLayout/PageLayout.module.scss
+++ b/src/layouts/PageLayout/PageLayout.module.scss
@@ -40,11 +40,13 @@
 
       .bk-page-layout__header__scope-switcher {
         @include typography.h6;
-        
-        > div {
-          border: none;
-        }
       }
     }
+  }
+}
+
+@layer baklava.overrides {
+  .bk-page-layout__header__scope-switcher > div {
+    border: none;
   }
 }


### PR DESCRIPTION
Resolves #462 
<img width="1859" height="1010" alt="Screenshot from 2025-08-29 17-43-42" src="https://github.com/user-attachments/assets/966f2f86-0a5c-4186-bc91-857b3bb7e0db" />
