### PR TITLE
Implement `CardAction` component

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -75,6 +75,8 @@ const preview = {
               'LinkAsButton',
               'Button',
               'ButtonAsLink',
+              'IconButton',
+              'CardAction',
             ],
             'overlays',
             [

--- a/src/components/actions/Button/Button.tsx
+++ b/src/components/actions/Button/Button.tsx
@@ -36,7 +36,10 @@ export type ButtonProps = React.PropsWithChildren<Omit<ComponentProps<'button'>,
   /** The kind of button, from higher prominance to lower. */
   kind?: undefined | 'primary' | 'secondary' | 'tertiary',
   
-  /** Which visual variant to use. Default: 'normal'. */
+  /**
+   * Which visual variant to use. Default: 'normal'.
+   * @deprecated The `card` variant is no longer used.
+   */
   variant?: undefined | 'normal' | 'card',
   
   /**

--- a/src/components/actions/CardAction/CardAction.module.scss
+++ b/src/components/actions/CardAction/CardAction.module.scss
@@ -31,6 +31,8 @@
       padding-block: $spacing calc(bk.$spacing-4 + $spacing);
       border-block-end: bk.$size-hairline solid bk.$theme-rule-default;
       
+      line-height: 1.2;
+      
       @include bk.font(bk.$font-family-display);
       font-size: bk.$font-size-xl;
       

--- a/src/components/actions/CardAction/CardAction.module.scss
+++ b/src/components/actions/CardAction/CardAction.module.scss
@@ -1,0 +1,86 @@
+/* Copyright (c) Fortanix, Inc.
+|* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of
+|* the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@use '../../../styling/defs.scss' as bk;
+
+@layer baklava.components {
+  // FIXME: we cannot do this from `@layer baklava.overrides`, because `Button` has a focus with `!important`
+  .bk-card-action .bk-card-action__action {
+    @include bk.focus-hidden;
+  }
+}
+
+// Use `overrides` layer to make sure we override the `.bk-card` styles
+@layer baklava.overrides {
+  .bk-card-action {
+    @include bk.component-base(bk-card-action);
+    
+    position: relative;
+    
+    padding-inline: bk.$spacing-7;
+    
+    // If there is only the action, make the padding symmetric (to center the action)
+    &:has(> .bk-card-action__action:only-child) {
+      padding: bk.$spacing-4;
+    }
+    
+    .bk-card-action__heading {
+      $spacing: calc(bk.$spacing-2 - 0.2lh); // Compensate a bit for the extra spacing from the `line-height`
+      margin-block-end: $spacing;
+      padding-block: $spacing calc(bk.$spacing-4 + $spacing);
+      border-block-end: bk.$size-hairline solid bk.$theme-rule-default;
+      
+      @include bk.font(bk.$font-family-display);
+      font-size: bk.$font-size-xl;
+      
+      > * {
+        white-space: wrap;
+      }
+    }
+    
+    .bk-card-action__content {
+      margin-block: bk.$spacing-4;
+    }
+    
+    .bk-card-action__action {
+      // Make sure there's no containment or transforms applied, otherwise the absolute positioning won't work
+      contain: initial;
+      transform: initial;
+      translate: initial;
+      rotate: initial;
+      scale: initial;
+      
+      &::after {
+        content: '';
+        display: block;
+        cursor: pointer;
+        position: absolute;
+        inset: 0;
+      }
+      
+      &.bk-card-action__action--link {
+        align-self: center;
+      }
+      
+      // Hide the default focus (move it to the card instead)
+      @include bk.focus-hidden;
+    }
+    
+    transition: border 150ms ease-in-out;
+    
+    &.bk-card-action--selected {
+      border-color: bk.$theme-card-border-selected;
+    }
+    &:not(.bk-card-action--selected) {
+      &:global(.pseudo-hover), &:has(.bk-card-action__action:hover) {
+        border-color: bk.$theme-card-border-hover;
+      }
+      &:global(.pseudo-focus-visible), &:has(.bk-card-action__action:focus-visible) {
+        border-color: bk.$theme-card-border-hover;
+      }
+    }
+    
+    @include bk.focus-outset($selector: '&:has(.bk-card-action__action:focus-visible), &.pseudo-focus-visible');
+  }
+}

--- a/src/components/actions/CardAction/CardAction.stories.tsx
+++ b/src/components/actions/CardAction/CardAction.stories.tsx
@@ -1,0 +1,144 @@
+/* Copyright (c) Fortanix, Inc.
+|* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of
+|* the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { LayoutDecorator } from '../../../util/storybook/LayoutDecorator.tsx';
+import { DummyBkLinkWithNotify } from '../../../util/storybook/StorybookLink.tsx';
+
+import { notify } from '../../overlays/ToastProvider/ToastProvider.tsx';
+import { Icon } from '../../graphics/Icon/Icon.tsx';
+import { Link } from '../Link/Link.tsx';
+import { LinkAsButton } from '../LinkAsButton/LinkAsButton.tsx';
+import { Card } from '../../containers/Card/Card.tsx';
+
+import { CardAction } from './CardAction.tsx';
+
+
+const handlePress = () => { notify.info('Pressed'); };
+const handleClick = (event: React.MouseEvent) => { event.preventDefault(); notify.info('Clicked'); };
+
+type CardActionArgs = React.ComponentProps<typeof CardAction>;
+type Story = StoryObj<CardActionArgs>;
+
+export default {
+  component: CardAction,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {},
+  args: {
+    children: (
+      <>
+        <CardAction.Content>Some content</CardAction.Content>
+        <CardAction.Button label="Action" onPress={handlePress}/>
+      </>
+    ),
+  },
+  render: (args) => <CardAction {...args}/>,
+  decorators: [Story => <LayoutDecorator size="x-small"><Story/></LayoutDecorator>],
+} satisfies Meta<CardActionArgs>;
+
+
+export const CardActionStandard: Story = {};
+
+export const CardActionHover: Story = {
+  args: {
+    className: 'pseudo-hover',
+    children: (
+      <>
+        <CardAction.Content>Some content</CardAction.Content>
+        <CardAction.Button label="Action" onPress={handlePress} className="pseudo-hover"/>
+      </>
+    ),
+  },
+};
+
+export const CardActionFocused: Story = {
+  args: {
+    className: 'pseudo-focus-visible',
+    children: (
+      <>
+        <CardAction.Content>Some content</CardAction.Content>
+        <CardAction.Button label="Action" onPress={handlePress} className="pseudo-focus-visible"/>
+      </>
+    ),
+  },
+};
+
+export const CardActionSelected: Story = {
+  args: {
+    selected: true,
+    children: (
+      <>
+        <CardAction.Button kind="tertiary" label="Selected" onPress={handlePress} icon="check"/>
+      </>
+    ),
+  },
+};
+
+export const CardActionWithCustomButton: Story = {
+  args: {
+    children: (
+      <>
+        <CardAction.Button kind="tertiary" label="Install" onPress={handlePress}
+          icon="install"
+        />
+      </>
+    ),
+  },
+};
+
+export const CardActionWithLink: Story = {
+  args: {
+    children: (
+      <>
+        <CardAction.Content>Some content</CardAction.Content>
+        <CardAction.Link Link={DummyBkLinkWithNotify}>Link</CardAction.Link>
+      </>
+    ),
+  },
+};
+
+const LinkAsButtonC = (props: React.ComponentProps<typeof Link>) =>
+  <LinkAsButton {...props} href="/" kind="primary" style={{ alignSelf: 'stretch' }} onClick={handleClick}/>;
+export const CardActionWithLinkAsButton: Story = {
+  args: {
+    children: (
+      <>
+        <CardAction.Content>Some content</CardAction.Content>
+        <CardAction.Link Link={LinkAsButtonC}>Link</CardAction.Link>
+      </>
+    ),
+  },
+};
+
+export const CardActionWithHeading: Story = {
+  args: {
+    children: (
+      <>
+        <CardAction.Heading icon={<Icon icon="account"/>}>Card heading – Will wrap if too long</CardAction.Heading>
+        <CardAction.Content>Content</CardAction.Content>
+        <CardAction.Button label="Action" onPress={handlePress}/>
+      </>
+    ),
+  },
+};
+
+export const CardActionWithSubgrid: Story = {
+  args: {
+    children: (
+      <>
+        <CardAction.Heading icon={<Icon icon="account"/>}>Card heading – Will wrap if too long</CardAction.Heading>
+        <CardAction.Content style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)' }}>
+          <Card flat>Cell 1</Card>
+          <Card flat>Cell 2</Card>
+        </CardAction.Content>
+        <CardAction.Button label="Action" onPress={handlePress}/>
+      </>
+    ),
+  },
+};

--- a/src/components/actions/CardAction/CardAction.tsx
+++ b/src/components/actions/CardAction/CardAction.tsx
@@ -1,0 +1,79 @@
+/* Copyright (c) Fortanix, Inc.
+|* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of
+|* the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react';
+import { classNames as cx, type ComponentProps } from '../../../util/componentUtil.ts';
+
+import { Button } from '../Button/Button.tsx';
+import { Link } from '../Link/Link.tsx';
+import { Card } from '../../containers/Card/Card.tsx';
+
+import cl from './CardAction.module.scss';
+
+
+export { cl as CardActionClassNames };
+
+const CardActionButton = (props: React.ComponentProps<typeof Button>) =>
+  <Button
+    kind="primary"
+    {...props}
+    className={cx(cl['bk-card-action__action'], cl['bk-card-action__action--button'], props.className)}
+  />;
+
+type CardActionLinkProps = React.ComponentProps<typeof Link> & {
+  Link?: undefined | React.ComponentType< React.ComponentProps<typeof Link>>,
+};
+const CardActionLink = ({ Link: LinkC = Link, ...propsRest }: CardActionLinkProps) =>
+  <LinkC
+    {...propsRest}
+    className={cx(cl['bk-card-action__action'], cl['bk-card-action__action--link'], propsRest.className)}
+  />;
+
+const CardActionHeading = (props: React.ComponentProps<typeof Card.Heading>) =>
+  <Card.Heading
+    {...props}
+    className={cx(cl['bk-card-action__heading'], props.className)}
+  />;
+
+const CardActionContent = (props: React.ComponentProps<'div'>) =>
+  <div
+    {...props}
+    className={cx(cl['bk-card-action__content'], props.className)}
+  />;
+
+export type CardActionProps = ComponentProps<typeof Card> & {
+  /** Whether this component should be unstyled. */
+  unstyled?: undefined | boolean,
+  
+  /** Whether the `CardAction` should be shown as selected. Default: `false`. */
+  selected?: undefined | boolean,
+};
+/**
+ * An interactive version of a `Card` component. `CardButton` presents itself to the user as clickable, focusable
+ * and possibly selectable component. Though for accessibility reasons, the actual interactive element ("action") must
+ * be a button or link embedded inside the card. Through CSS the interactive area of the action gets extended to the
+ * boundary of the `CardAction` component.
+ */
+export const CardAction = Object.assign(
+  (props: CardActionProps) => {
+    const { unstyled = false, selected = false, ...propsRest } = props;
+    return (
+      <Card
+        {...propsRest}
+        className={cx(
+          'bk',
+          { [cl['bk-card-action']]: !unstyled },
+          { [cl['bk-card-action--selected']]: selected },
+          propsRest.className,
+        )}
+      />
+    );
+  },
+  {
+    Button: CardActionButton,
+    Link: CardActionLink,
+    Heading: CardActionHeading,
+    Content: CardActionContent,
+  },
+);

--- a/src/components/actions/LinkAsButton/LinkAsButton.tsx
+++ b/src/components/actions/LinkAsButton/LinkAsButton.tsx
@@ -17,13 +17,13 @@ type LinkAsButtonProps = LinkProps & {
   
   // Link props
   //size?: LinkProps['size'], // Not relevant
-  label?: NonNullable<LinkProps['label']>,
+  label?: undefined | NonNullable<LinkProps['label']>,
   
   // Button props
-  kind?: NonNullable<ButtonProps['kind']>,
-  nonactive?: NonNullable<ButtonProps['nonactive']>,
-  disabled?: NonNullable<ButtonProps['disabled']>,
-  trimmed?: NonNullable<ButtonProps['trimmed']>,
+  kind?: undefined | NonNullable<ButtonProps['kind']>,
+  nonactive?: undefined | NonNullable<ButtonProps['nonactive']>,
+  disabled?: undefined | NonNullable<ButtonProps['disabled']>,
+  trimmed?: undefined | NonNullable<ButtonProps['trimmed']>,
 };
 
 /**

--- a/src/components/containers/Card/Card.module.scss
+++ b/src/components/containers/Card/Card.module.scss
@@ -12,7 +12,7 @@
   overflow: hidden;
   
   &:where(:not(.#{$name}--flat)) {
-    min-block-size: bk.$spacing-16;
+    //min-block-size: bk.$spacing-16;
     padding: bk.$spacing-4;
     padding-block-end: bk.$spacing-8;
     
@@ -24,18 +24,24 @@
   @include bk.flex-column;
   
   .#{$name}__heading {
-    &.#{$name}__heading-link {
+    &.#{$name}__heading--link {
       align-self: start;
       max-inline-size: 100%;
       cursor: pointer;
       @include heading.h5;
     }
     
-    &, &.#{$name}__heading-link { // Note: need the extra specificity to override the above
+    margin-block-end: bk.$spacing-5;
+    
+    display: flex;
+    align-items: center;
+    gap: 0.8ch;
+    
+    .#{$name}__heading__icon { --keep: ; }
+    
+    .#{$name}__heading__content {
       @include bk.text-one-line;
     }
-    
-    margin-block-end: bk.$spacing-5;
   }
   
   &.#{$name}--flat > .#{$name}__heading {

--- a/src/components/containers/Card/Card.stories.tsx
+++ b/src/components/containers/Card/Card.stories.tsx
@@ -9,6 +9,7 @@ import { DummyBkLinkWithNotify } from '../../../util/storybook/StorybookLink.tsx
 import { LayoutDecorator } from '../../../util/storybook/LayoutDecorator.tsx';
 import type { Meta, StoryObj } from '@storybook/react';
 
+import { Icon } from '../../graphics/Icon/Icon.tsx';
 import { Banner } from '../Banner/Banner.tsx';
 
 import { Card } from './Card.tsx';
@@ -61,6 +62,18 @@ export const CardWithHeadingOverflow: Story = {
   },
 };
 
+export const CardWithHeadingAndIcon: Story = {
+  decorators: [Story => <LayoutDecorator size="small"><Story/></LayoutDecorator>],
+  args: {
+    children: (
+      <>
+        <Card.Heading icon={<Icon icon="account"/>}>{loremIpsumSentence}</Card.Heading>
+        <LoremIpsum/>
+      </>
+    ),
+  },
+};
+
 export const CardWithHeadingLink: Story = {
   decorators: [Story => <LayoutDecorator size="small"><Story/></LayoutDecorator>],
   args: {
@@ -79,6 +92,20 @@ export const CardWithHeadingLinkOverflow: Story = {
     children: (
       <>
         <Card.HeadingLink Link={DummyBkLinkWithNotify}>{loremIpsumSentence}</Card.HeadingLink>
+        <LoremIpsum/>
+      </>
+    ),
+  },
+};
+
+export const CardWithHeadingLinkAndIcon: Story = {
+  decorators: [Story => <LayoutDecorator size="small"><Story/></LayoutDecorator>],
+  args: {
+    children: (
+      <>
+        <Card.HeadingLink Link={DummyBkLinkWithNotify} icon={<Icon icon="account"/>}>
+          {loremIpsumSentence}
+        </Card.HeadingLink>
         <LoremIpsum/>
       </>
     ),

--- a/src/components/containers/Card/Card.tsx
+++ b/src/components/containers/Card/Card.tsx
@@ -13,21 +13,32 @@ import cl from './Card.module.scss';
 export { cl as CardClassNames };
 
 
-export type CardHeadingProps = ComponentProps<typeof H5>;
-export const CardHeading = (props: CardHeadingProps) => {
-  return <H5 {...props} className={cx(cl['bk-card__heading'], props.className)}/>;
+export type CardHeadingProps = ComponentProps<typeof H5> & {
+  icon?: undefined | React.ReactElement,
+};
+export const CardHeading = ({ icon, ...propsRest }: CardHeadingProps) => {
+  return (
+    <H5 {...propsRest} className={cx(cl['bk-card__heading'], propsRest.className)}>
+      {icon && <span className={cx(cl['bk-card__heading__icon'])}>{icon}</span>}
+      <span className={cx(cl['bk-card__heading__content'])}>{propsRest.children}</span>
+    </H5>
+  );
 };
 
 export type CardHeadingLinkProps = ComponentProps<typeof LinkDefault> & {
+  icon?: undefined | React.ReactElement,
   Link?: undefined | typeof LinkDefault,
 };
-export const CardHeadingLink = ({ Link = LinkDefault, ...propsRest }: CardHeadingLinkProps) => {
+export const CardHeadingLink = ({ icon, Link = LinkDefault, ...propsRest }: CardHeadingLinkProps) => {
   return (
     <Link
       unstyled
       {...propsRest}
-      className={cx(cl['bk-card__heading'], cl['bk-card__heading-link'], propsRest.className)}
-    />
+      className={cx(cl['bk-card__heading'], cl['bk-card__heading--link'], propsRest.className)}
+    >
+      {icon && <span className={cx(cl['bk-card__heading__icon'])}>{icon}</span>}
+      <span className={cx(cl['bk-card__heading__content'])}>{propsRest.children}</span>
+    </Link>
   );
 };
 

--- a/src/components/forms/controls/TextArea/TextArea.module.scss
+++ b/src/components/forms/controls/TextArea/TextArea.module.scss
@@ -9,9 +9,9 @@
     @include bk.component-base(bk-textarea);
     
     @include bk.focus-hidden;
-
+    
     --bk-text-area-border-color: #{bk.$theme-text-area-border-filled};
-
+    
     border: bk.rem-from-px(1) solid var(--bk-text-area-border-color);
     border-radius: bk.$radius-1;
     color: bk.$theme-text-area-text-filled;
@@ -24,13 +24,13 @@
     &:placeholder-shown {
       --bk-text-area-border-color: #{bk.$theme-text-area-border-default};
     }
-
+    
     &:disabled {
       color: bk.$theme-text-area-text-disabled;
       --bk-text-area-border-color: #{bk.$theme-text-area-border-disabled};
     }
   }
-
+  
   .bk-text-area--invalid, .bk-text-area--invalid:placeholder-shown {
     --bk-text-area-border-color: #{bk.$theme-text-area-border-error};
   }
@@ -44,7 +44,7 @@
     color: bk.$theme-text-area-text-focused;
     --bk-text-area-border-color: #{bk.$theme-text-area-border-focused};
   }
-
+  
   .bk-text-area--automatic-resize {
     field-sizing: content;
   }

--- a/src/components/graphics/Icon/Icon.tsx
+++ b/src/components/graphics/Icon/Icon.tsx
@@ -50,17 +50,19 @@ export type IconProps = React.PropsWithChildren<ComponentProps<'svg'> & {
 export const Icon = Object.assign(
   ({ unstyled, icon, color = 'currentColor', decoration, ...props }: IconProps) => {
     const symbolId = `#baklava-icon-${icon}`;
-
+    
     return (
       <svg
-        role="img"
+        role="presentation"
         aria-hidden // https://stackoverflow.com/questions/61048356/why-do-we-use-aria-hidden-with-icons
         {...props}
-        className={cx({
-          bk: true,
-          [cl['bk-icon']]: !unstyled,
-          [cl['bk-icon--background-circle']]: decoration?.type === 'background-circle',
-        }, props.className)}
+        className={cx(
+          'bk',
+          'icon', // Global class name (for generic targeting in CSS)
+          { [cl['bk-icon']]: !unstyled },
+          { [cl['bk-icon--background-circle']]: decoration?.type === 'background-circle' },
+          props.className,
+        )}
       >
         <use href={symbolId} fill={color}/>
       </svg>

--- a/src/layouts/AppLayout/AppLayout.module.scss
+++ b/src/layouts/AppLayout/AppLayout.module.scss
@@ -17,7 +17,7 @@
   }
 }
 
-@layer baklava.components {
+@layer baklava.layouts {
   .bk-app-layout {
     @include bk.component-base(bk-app-layout);
     container-type: inline-size;

--- a/src/layouts/DialogLayout/DialogLayout.module.scss
+++ b/src/layouts/DialogLayout/DialogLayout.module.scss
@@ -4,7 +4,7 @@
 
 @use '../../styling/defs.scss' as bk;
 
-@layer baklava.components {
+@layer baklava.layouts {
   .bk-dialog-layout {
     @include bk.component-base(bk-dialog-layout);
     

--- a/src/layouts/FormLayout/FormLayout.module.scss
+++ b/src/layouts/FormLayout/FormLayout.module.scss
@@ -4,7 +4,7 @@
 
 @use '../../styling/defs.scss' as bk;
 
-@layer baklava.components {
+@layer baklava.layouts {
   .bk-form-layout {
     @include bk.component-base(bk-form-layout);
     

--- a/src/layouts/PageLayout/PageLayout.module.scss
+++ b/src/layouts/PageLayout/PageLayout.module.scss
@@ -5,7 +5,7 @@
 @use '../../styling/defs.scss' as bk;
 @use '../../styling/features/typography.scss' as typography;
 
-@layer baklava.components {
+@layer baklava.layouts {
   .bk-page-layout {
     @include bk.component-base(bk-page-layout);
 

--- a/src/layouts/PublicLayout/PublicLayout.module.scss
+++ b/src/layouts/PublicLayout/PublicLayout.module.scss
@@ -4,7 +4,7 @@
 
 @use '../../styling/defs.scss' as bk;
 
-@layer baklava.components {
+@layer baklava.layouts {
   .bk-fortanix-armor-logo {
     @include bk.component-base(bk-fortanix-armor-logo);
     

--- a/src/styling/layers.scss
+++ b/src/styling/layers.scss
@@ -28,7 +28,8 @@ of `preview-head.html`.
     baklava.theming, // Themes (e.g. light/dark mode)
     baklava.prose, // Default semantic HTML styling for prose sections
     baklava.components, // Component styling
-    baklava.overrides; // Local overrides (e.g. components that need to override other components)
+    baklava.overrides, // Local overrides (e.g. components that need to override other components)
+    baklava.layouts; // For layout components (specialized versions of components)
   
   // (*) In the future, we could maybe use caret syntax for this instead, so that consumer applications just use regular
   // unlayered styling and anything that needs higher precedence uses `@layer ^my-layer`.

--- a/src/styling/variables.scss
+++ b/src/styling/variables.scss
@@ -39,6 +39,7 @@ $spacing-17: round(math.div(224, 14) * 1rem, 1px) !default; // ~224px
 $spacing-18: round(math.div(256, 14) * 1rem, 1px) !default; // ~256px
 
 // These sizes do not match Figma variables
+$size-hairline: math.div(1, 14) * 1rem !default; // ~1px
 $size-1: math.div(1, 14) * 1rem !default; // ~1px
 $size-2: math.div(2, 14) * 1rem !default; // ~2px
 $size-3: math.div(3, 14) * 1rem !default; // ~3px

--- a/src/util/storybook/LayoutDecorator.module.scss
+++ b/src/util/storybook/LayoutDecorator.module.scss
@@ -9,6 +9,7 @@
     padding: var(--bk-focus-outline-width); // Add some spacing so as not to cut off any focus outlines
     
     --util-layout-decorator-size: 80ch;
+    &.util-layout-decorator--x-small { --util-layout-decorator-size: 40ch; }
     &.util-layout-decorator--small { --util-layout-decorator-size: 60ch; }
     &.util-layout-decorator--medium { --util-layout-decorator-size: 80ch; }
     &.util-layout-decorator--large { --util-layout-decorator-size: 100ch; }

--- a/src/util/storybook/LayoutDecorator.tsx
+++ b/src/util/storybook/LayoutDecorator.tsx
@@ -11,7 +11,7 @@ import cl from './LayoutDecorator.module.scss';
  * Utility component to wrap around storybook stories to provide a nicer base layout.
  */
 export type LayoutDecoratorProps = ComponentProps<'div'> & {
-  size?: undefined | 'small' | 'medium' | 'large' | 'x-large',
+  size?: undefined | 'x-small' | 'small' | 'medium' | 'large' | 'x-large',
   resize?: undefined | 'none' | 'inline' | 'block' | 'both',
 };
 export const LayoutDecorator = (props: LayoutDecoratorProps) => {
@@ -27,6 +27,7 @@ export const LayoutDecorator = (props: LayoutDecoratorProps) => {
       {...propsRest}
       className={cx(
         { [cl['util-layout-decorator']]: true },
+        { [cl['util-layout-decorator--x-small']]: size === 'x-small' },
         { [cl['util-layout-decorator--small']]: size === 'small' },
         { [cl['util-layout-decorator--medium']]: size === 'medium' },
         { [cl['util-layout-decorator--large']]: size === 'large' },


### PR DESCRIPTION
This PR implements a new `CardAction` component, which is a type of action (an interactive component that can be activated, similar to `Button` and `Link`), but displayed as a card.

<img width="356" height="264" alt="Screenshot 2025-09-06 at 18 55 59" src="https://github.com/user-attachments/assets/0fc54107-64cd-464e-a783-c8be3f8fbb21" />

Resolves #355