### PR TITLE
Fix styling regression in existing usages of `Card.Heading`

### DIFF
--- a/src/components/containers/Card/Card.module.scss
+++ b/src/components/containers/Card/Card.module.scss
@@ -33,14 +33,21 @@
     
     margin-block-end: bk.$spacing-5;
     
-    display: flex;
-    align-items: center;
-    gap: 0.8ch;
-    
-    .#{$name}__heading__icon { --keep: ; }
-    
-    .#{$name}__heading__content {
+    // Note: use `:has()` here so that we don't break existing usages of this component without the additional
+    // `<span>` nested elements
+    &:not(:has(.#{$name}__heading__content)) {
       @include bk.text-one-line;
+    }
+    &:has(.#{$name}__heading__content) {
+      display: flex;
+      align-items: center;
+      gap: 0.8ch;
+      
+      .#{$name}__heading__icon { --keep: ; }
+      
+      .#{$name}__heading__content {
+        @include bk.text-one-line;
+      }
     }
   }
   

--- a/src/components/containers/Card/Card.tsx
+++ b/src/components/containers/Card/Card.tsx
@@ -19,8 +19,13 @@ export type CardHeadingProps = ComponentProps<typeof H5> & {
 export const CardHeading = ({ icon, ...propsRest }: CardHeadingProps) => {
   return (
     <H5 {...propsRest} className={cx(cl['bk-card__heading'], propsRest.className)}>
-      {icon && <span className={cx(cl['bk-card__heading__icon'])}>{icon}</span>}
-      <span className={cx(cl['bk-card__heading__content'])}>{propsRest.children}</span>
+      {icon &&
+        <>
+          <span className={cx('_icon', cl['bk-card__heading__icon'])}>{icon}</span>
+          <span className={cx('_content', cl['bk-card__heading__content'])}>{propsRest.children}</span>
+        </>
+      }
+      {!icon && propsRest.children}
     </H5>
   );
 };
@@ -36,8 +41,13 @@ export const CardHeadingLink = ({ icon, Link = LinkDefault, ...propsRest }: Card
       {...propsRest}
       className={cx(cl['bk-card__heading'], cl['bk-card__heading--link'], propsRest.className)}
     >
-      {icon && <span className={cx(cl['bk-card__heading__icon'])}>{icon}</span>}
-      <span className={cx(cl['bk-card__heading__content'])}>{propsRest.children}</span>
+      {icon &&
+        <>
+          <span className={cx('_icon', cl['bk-card__heading__icon'])}>{icon}</span>
+          <span className={cx('_content', cl['bk-card__heading__content'])}>{propsRest.children}</span>
+        </>
+      }
+      {!icon && propsRest.children}
     </Link>
   );
 };

--- a/src/layouts/PublicLayout/PublicLayout.module.scss
+++ b/src/layouts/PublicLayout/PublicLayout.module.scss
@@ -69,7 +69,7 @@
       
       font-size: bk.$font-size-l;
       
-      [role="img"] {
+      :global(.icon) {
         font-size: 2em;
       }
     }


### PR DESCRIPTION
#476 causes some regressions due to change in HTML structure for `Card.Heading` and `Card.HeadingLink`. This PR fixes it by supporting both the old structure and new structure.

Example of the regression (here in the `PublicLayout` component), where the icon is not rendered as it should be:

<img width="831" height="503" alt="Screenshot 2025-09-08 at 14 41 34" src="https://github.com/user-attachments/assets/2377c770-a81e-439f-87d6-bae8f2d157d3" />
