### PR TITLE
`InputSensitive` – Fix `bk-sensitive-input--revealed` naming being inverted

### DIFF
--- a/src/components/forms/controls/Input/InputSensitive.module.scss
+++ b/src/components/forms/controls/Input/InputSensitive.module.scss
@@ -8,7 +8,7 @@
   .bk-sensitive-input {
     @include bk.component-base(bk-sensitive-input);
     
-    &.bk-sensitive-input--revealed {
+    &:not(.bk-sensitive-input--revealed) {
       // Note: this property is nonstandard, but it is supported by all major browsers. There is a proposal to bring
       // this to CSS (https://drafts.csswg.org/css-ui/#input-security), but as per discussion this may end up being
       // a standard UA feature instead.

--- a/src/components/forms/controls/Input/InputSensitive.tsx
+++ b/src/components/forms/controls/Input/InputSensitive.tsx
@@ -24,8 +24,8 @@ type InputSensitiveProps = Omit<React.ComponentProps<typeof Input>, 'ref'> & {
   allowReveal?: undefined | boolean,
 };
 /**
- * A input for sensitive text. By default, the input will be masked and copying to the clipboard will not work. If
- * `allowReveal` is true, the user will be able to reveal the contents of the input.
+ * An input for sensitive text. By default, the input will be masked and copying to the clipboard will not work. If
+ * `allowReveal` is set to true, the user will be able to reveal the contents of the input.
  * 
  * Note: this is not meant for passwords, use `InputPassword` for that instead. The `InputSensitive` does not integrate
  * with password managers.
@@ -72,7 +72,7 @@ export const InputSensitive = (props: InputSensitiveProps) => {
       className={cx(
         cl['bk-sensitive-input'],
         // Note: this class triggers `-webkit-text-security`, but that does not have any effect for `type="password"`
-        { [cl['bk-sensitive-input--revealed']]: !isRevealed },
+        { [cl['bk-sensitive-input--revealed']]: isRevealed },
         propsRest.className,
       )}
       type={inputType}
@@ -83,8 +83,8 @@ export const InputSensitive = (props: InputSensitiveProps) => {
             hidden={!allowReveal}
             icon={isRevealed ? 'eye-open' : 'eye-closed'}
             label={isRevealed
-              ? `${capitalizeFirstLetter(contentLabel)} is revealed`
-              : `${capitalizeFirstLetter(contentLabel)} is hidden`
+              ? `Hide ${capitalizeFirstLetter(contentLabel)}`
+              : `Reveal ${capitalizeFirstLetter(contentLabel)}`
             }
             onPress={toggleRevealed}
           />


### PR DESCRIPTION
This PR fixes a few (non-functional) issues in the `InputSensitive` component