### PR TITLE
Prevent dialog close events bubbling up in React

### DIFF
--- a/src/components/containers/Dialog/Dialog.tsx
+++ b/src/components/containers/Dialog/Dialog.tsx
@@ -91,7 +91,7 @@ export type DialogProps = Omit<ComponentProps<'dialog'>, 'title'> & {
   
   /** If specified, a close action is displayed in the footer. Default: true. */
   showCancelAction?: undefined | boolean,
-  
+
   /** Callback that is called when the user requests the dialog to close. */
   onRequestClose?: undefined | (() => void), // Note: cannot name this `onClose`, dialog already has an `onClose` prop
   
@@ -116,6 +116,7 @@ export const Dialog = Object.assign(
       title,
       showCloseIcon = true,
       showCancelAction = true,
+      onClose,
       onRequestClose,
       actions,
       autoFocusClose = false,
@@ -135,6 +136,13 @@ export const Dialog = Object.assign(
       close: onRequestClose ?? (() => { console.warn('Missing `onRequestClose` callback.'); })
     }), [onRequestClose]);
     
+    const handleClose = React.useCallback((event: React.SyntheticEvent<HTMLDialogElement>) => {
+      // Workaround for a bug in React where the close event will bubble up to parent components, even though native
+      // close events do not bubble.
+      event.stopPropagation();
+      onClose?.(event);
+    }, [onClose]);
+    
     return (
       <DialogContext value={dialogContext}>
         <dialog
@@ -153,6 +161,7 @@ export const Dialog = Object.assign(
             scrollerProps.className,
             propsRest.className,
           )}
+          onClose={handleClose}
         >
           <header className={cx(cl['bk-dialog__header'])}>
             <H5 id={`${dialogId}-title`} className={cx(cl['bk-dialog__header__title'])}>{title}</H5>

--- a/src/components/overlays/DialogModal/DialogModal.stories.tsx
+++ b/src/components/overlays/DialogModal/DialogModal.stories.tsx
@@ -95,6 +95,41 @@ export const DialogModalNested: Story = {
   },
 };
 
+const DialogModalNestedCloseTestC = (args: DialogModalArgs) => {
+  const modalRef = DialogModal.useModalRef();
+  
+  return (
+    <DialogModal {...args} modalRef={modalRef}>
+      <Button kind="primary" label="Close inner modal" onPress={() => { modalRef.current?.deactivate(); }}/>
+    </DialogModal>
+  );
+};
+export const DialogModalNestedCloseTest: Story = {
+  args: {
+    title: 'Modal with a submodal',
+    className: 'outer',
+    // The inner close event should not bubble, but there seems to be a bug in React's event handling:
+    // https://github.com/facebook/react/issues/34038
+    onClose: event => {
+      if (event.target instanceof HTMLDialogElement && event.target.className.includes('inner')) {
+        notify.error('BUG: outer modal received close event for the inner dialog modal');
+      }
+    },
+    children: (
+      <DialogModalNestedCloseTestC
+        className="inner"
+        title="Submodal"
+        trigger={({ activate }) => <Button kind="primary" label="Open submodal" onPress={activate}/>}
+        onClose={() => {
+          notify.success('Successfully received close event for the inner dialog modal');
+        }}
+      >
+        This is a submodal. Closing this modal should keep the outer modal still open.
+      </DialogModalNestedCloseTestC>
+    ),
+  },
+};
+
 export const DialogModalWithTooltip: Story = {
   args: {
     title: 'Modal with a tooltip',


### PR DESCRIPTION
Resolves #534 

This PR implements a workaround for the React bug described in: https://github.com/facebook/react/issues/34038

To work around the issue, we catch all `close` events and use `event.stopPropagation()` to prevent React bubbling the event up to parent components.