### PR TITLE
`DataTable` select all event bubbling bug fix

### DIFF
--- a/src/components/tables/DataTable/plugins/useRowSelectColumn.tsx
+++ b/src/components/tables/DataTable/plugins/useRowSelectColumn.tsx
@@ -32,11 +32,9 @@ export const useRowSelectColumn = <D extends object>(hooks: ReactTable.Hooks<D>)
                   <Checkbox
                     aria-label="Select all rows"
                     checked={checked}
-                    onClick={(e) => e.stopPropagation()}
-                    onChange={(e) => {
-                      e.stopPropagation();
-                      onChange?.(e);
-                    }}
+                    // Prevent the click event from triggering a click on the parent table header/cell
+                    onClick={event => { event.stopPropagation(); }}
+                    onChange={onChange}
                     className={cl['bk-data-table-row-select__checkbox']}
                   />
                 )}
@@ -56,11 +54,9 @@ export const useRowSelectColumn = <D extends object>(hooks: ReactTable.Hooks<D>)
                 <Checkbox
                   aria-label="Select row"
                   checked={checked}
-                  onClick={(e) => e.stopPropagation()}
-                  onChange={(e) => {
-                    e.stopPropagation();
-                    onChange?.(e);
-                  }}
+                  // Prevent the click event from triggering a click on the parent table header/cell
+                  onClick={event => { event.stopPropagation(); }}
+                  onChange={onChange}
                   className={cl['bk-data-table-row-select__checkbox']}
                 />
                 {cellContent}


### PR DESCRIPTION
Fixed the event bubbling issue for select all `onClick` in the `useRowSelectColumn` plugin function.

Select all `onClick` events that were bubbling up to cause the header click, which was triggering the sort for the first column.

https://fortanix.atlassian.net/browse/KI-4398?atlOrigin=eyJpIjoiMTI5MWVlNzk2MzhmNDY2NTllMzRiNWM0OGI0NjdmY2UiLCJwIjoiaiJ9