### PR TITLE
Fixed page scroll when the dropdown is selected

### DIFF
--- a/src/legacy/components/forms/Select/LazySelect/LazySelect.tsx
+++ b/src/legacy/components/forms/Select/LazySelect/LazySelect.tsx
@@ -414,10 +414,12 @@ export const LazySelect = <D extends object, P extends unknown = undefined>(prop
   // due to the lazy loading, handling focus on select item after item is loaded
   React.useEffect(() => {
     if (isActive && items.length > 0) {
+      const { scrollX, scrollY } = window;
       const selectedIndex = optionsRef.current.findIndex(item => item?.getAttribute('aria-selected') === 'true');
       const focusIndex = selectedIndex === -1 ? findFirstFocusableIndex(optionsRef.current) : selectedIndex;
       optionsRef.current[focusIndex]?.focus();
       optionsRef.current[focusIndex]?.scrollIntoView({ block: 'nearest' });
+      window.scrollTo(scrollX, scrollY);
     }
   }, [isActive, items]);
 

--- a/src/legacy/components/forms/Select/MultiSelect/MultiSelect.tsx
+++ b/src/legacy/components/forms/Select/MultiSelect/MultiSelect.tsx
@@ -104,8 +104,10 @@ export const MultiSelect = (props: MultiSelectProps) => {
   // Scroll to selected item when select item is opened
   React.useEffect(() => {
     if (isActive && optionsRef.current.length > 0) {
+      const { scrollX, scrollY } = window;
       const selectedItem = optionsRef.current.find(item => item?.checked);
       selectedItem?.scrollIntoView({ block: 'nearest' });
+      window.scrollTo(scrollX, scrollY);
     }
   }, [optionsRef, isActive]);
   

--- a/src/legacy/components/forms/Select/Select.tsx
+++ b/src/legacy/components/forms/Select/Select.tsx
@@ -100,8 +100,13 @@ export const Select = (props: SelectProps) => {
   // Scroll to selected item when select item is opened
   React.useEffect(() => {
     if (isActive && optionsRef.current.length > 0) {
+      const { scrollX, scrollY } = window;
       const selectedItem = optionsRef.current.find(item => item.getAttribute('aria-selected') === 'true');
       selectedItem?.scrollIntoView({ block: 'nearest' });
+      // If there is a scroll in the page and dropdown is selected, on click of the dropdown the entire page scrolls up.
+      // This is an issue with `scrollIntoView`.
+      // To fix this, we have to retain the initial position of the dropdown and scroll to the same position.
+      window.scrollTo(scrollX, scrollY);
     }
   }, [isActive]);
   
@@ -116,6 +121,7 @@ export const Select = (props: SelectProps) => {
     setIsActive(false);
     setIsOptionSelected(true);
   };
+  
   
   const renderOptions = () => {
     return Object.entries(options).map(([key, { label, disabled: optionDisabled }], index) =>


### PR DESCRIPTION
There is an issue in DSM `https://fortanix.atlassian.net/browse/ROFR-5719` where the page scrolls up when the curve dropdown is selected. 

This is because of scrollIntoView which is used to scroll to the seleced item in the dropdown.

To fix this, we have to retain the initial position of the dropdown and scroll to the same position.