### PR TITLE
(#586) Fixed multi search dropdown stays visible for 500ms

### DIFF
--- a/src/components/overlays/MenuLazyProvider/MenuLazyProvider.tsx
+++ b/src/components/overlays/MenuLazyProvider/MenuLazyProvider.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 
 // Utils
 import { classNames as cx, type ComponentProps } from '../../../util/componentUtil.ts';
-import { mergeCallbacks, mergeRefs } from '../../../util/reactUtil.ts';
+import { mergeCallbacks, mergeProps, mergeRefs } from '../../../util/reactUtil.ts';
 import { type UseFloatingElementOptions } from '../../util/overlays/floating-ui/useFloatingElement.tsx';
 
 // Components
@@ -185,10 +185,16 @@ export const MenuLazyProvider = (props: MenuLazyProviderProps) => {
   const floatingProps = getFloatingProps({
     popover: 'manual',
     style: floatingStyles,
-    ...propsRest,
-    className: cx(cl['bk-menu-provider__list-box'], propsRest.className),
-    onKeyDown: mergeCallbacks([propsRest.onKeyDown, onMenuKeyDown]),
+    className: cx(cl['bk-menu-provider__list-box']),
   });
+
+  const mergedProps = mergeProps(
+    floatingProps,
+    propsRest,
+    {
+      onKeyDown: mergeCallbacks([propsRest.onKeyDown, onMenuKeyDown]),
+    },
+  );
 
   const mergedListBoxRef = mergeRefs<React.ComponentRef<typeof ListBoxLazy.ListBoxLazy>>(
     listBoxRef,
@@ -212,8 +218,7 @@ export const MenuLazyProvider = (props: MenuLazyProviderProps) => {
       {anchor}
       {isMounted && (
         <ListBoxLazy.ListBoxLazy
-          {...propsRest}
-          {...floatingProps} // Merge order matters: `floatingProps` overrides any conflicting keys in `propsRest`.
+          {...mergedProps}
           ref={mergedListBoxRef}
           size={menuSize}
           label={label}

--- a/src/components/overlays/MenuMultiLazyProvider/MenuMultiLazyProvider.tsx
+++ b/src/components/overlays/MenuMultiLazyProvider/MenuMultiLazyProvider.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 
 // Utils
 import { classNames as cx, type ComponentProps } from '../../../util/componentUtil.ts';
-import { mergeCallbacks, mergeRefs } from '../../../util/reactUtil.ts';
+import { mergeCallbacks, mergeProps, mergeRefs } from '../../../util/reactUtil.ts';
 import { type UseFloatingElementOptions } from '../../util/overlays/floating-ui/useFloatingElement.tsx';
 
 // Components
@@ -178,10 +178,16 @@ export const MenuMultiLazyProvider = (props: MenuMultiLazyProviderProps) => {
   const floatingProps = getFloatingProps({
     popover: 'manual',
     style: floatingStyles,
-    ...propsRest,
-    className: cx(cl['bk-menu-provider__list-box'], propsRest.className),
-    onKeyDown: mergeCallbacks([propsRest.onKeyDown, onMenuKeyDown]),
+    className: cx(cl['bk-menu-provider__list-box']),
   });
+
+  const mergedProps = mergeProps(
+    floatingProps,
+    propsRest,
+    {
+      onKeyDown: mergeCallbacks([propsRest.onKeyDown, onMenuKeyDown]),
+    },
+  );
 
   const mergedListBoxRef = mergeRefs<React.ComponentRef<typeof ListBoxMultiLazy.ListBoxMultiLazy>>(
     listBoxRef,
@@ -207,8 +213,7 @@ export const MenuMultiLazyProvider = (props: MenuMultiLazyProviderProps) => {
       {anchor}
       {isMounted && (
         <ListBoxMultiLazy.ListBoxMultiLazy
-          {...propsRest}
-          {...floatingProps} // Merge order matters: `floatingProps` overrides any conflicting keys in `propsRest`.
+          {...mergedProps}
           ref={mergedListBoxRef}
           size={menuSize}
           label={label}

--- a/src/components/overlays/MenuMultiProvider/MenuMultiProvider.tsx
+++ b/src/components/overlays/MenuMultiProvider/MenuMultiProvider.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 
 // Utils
 import { classNames as cx, type ComponentProps } from '../../../util/componentUtil.ts';
-import { mergeCallbacks, mergeRefs, useRefWithInitializer } from '../../../util/reactUtil.ts';
+import { mergeCallbacks, mergeProps, mergeRefs, useRefWithInitializer } from '../../../util/reactUtil.ts';
 import {
   type UseFloatingElementOptions,
   UseFloatingElementResult,
@@ -597,10 +597,16 @@ export const MenuMultiProvider = Object.assign((props: MenuMultiProviderProps) =
   const floatingProps = getFloatingProps({
     popover: 'manual',
     style: floatingStyles,
-    ...propsRest,
-    className: cx(cl['bk-menu-provider__list-box'], propsRest.className),
-    onKeyDown: mergeCallbacks([propsRest.onKeyDown, onMenuKeyDown]),
+    className: cx(cl['bk-menu-provider__list-box']),
   });
+
+  const mergedProps = mergeProps(
+    floatingProps,
+    propsRest,
+    {
+      onKeyDown: mergeCallbacks([propsRest.onKeyDown, onMenuKeyDown]),
+    },
+  );
 
   const mergedListBoxRef = mergeRefs<React.ComponentRef<typeof ListBoxMulti.ListBoxMulti>>(
     listBoxRef,
@@ -626,8 +632,7 @@ export const MenuMultiProvider = Object.assign((props: MenuMultiProviderProps) =
       {anchor}
       {isMounted && (
         <ListBoxMulti.ListBoxMulti
-          {...propsRest}
-          {...floatingProps} // Merge order matters: `floatingProps` overrides any conflicting keys in `propsRest`.
+          {...mergedProps}
           ref={mergedListBoxRef}
           size={menuSize}
           label={label}

--- a/src/components/overlays/MenuProvider/MenuProvider.tsx
+++ b/src/components/overlays/MenuProvider/MenuProvider.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 
 // Utils
 import { classNames as cx, type ComponentProps } from '../../../util/componentUtil.ts';
-import { mergeCallbacks, mergeRefs } from '../../../util/reactUtil.ts';
+import { mergeCallbacks, mergeProps, mergeRefs } from '../../../util/reactUtil.ts';
 import {
   type UseFloatingElementOptions,
 } from '../../util/overlays/floating-ui/useFloatingElement.tsx';
@@ -191,10 +191,16 @@ export const MenuProvider = Object.assign((props: MenuProviderProps) => {
   const floatingProps = getFloatingProps({
     popover: 'manual',
     style: floatingStyles,
-    ...propsRest,
-    className: cx(cl['bk-menu-provider__list-box'], propsRest.className),
-    onKeyDown: mergeCallbacks([propsRest.onKeyDown, onMenuKeyDown]),
+    className: cx(cl['bk-menu-provider__list-box']),
   });
+
+  const mergedProps = mergeProps(
+    floatingProps,
+    propsRest,
+    {
+      onKeyDown: mergeCallbacks([propsRest.onKeyDown, onMenuKeyDown]),
+    },
+  );
 
   const mergedListBoxRef = mergeRefs<React.ComponentRef<typeof ListBox.ListBox>>(
     listBoxRef,
@@ -218,8 +224,7 @@ export const MenuProvider = Object.assign((props: MenuProviderProps) => {
       {anchor}
       {isMounted && (
         <ListBox.ListBox
-          {...propsRest}
-          {...floatingProps} // Merge order matters: `floatingProps` overrides any conflicting keys in `propsRest`.
+          {...mergedProps}
           ref={mergedListBoxRef}
           size={menuSize}
           label={label}


### PR DESCRIPTION
During refactoring of MenuProvider, I added the following. But the ordering of the props does matter.
className prop was overridden when spreading propsRest
`<ListBox.ListBox`
`          {…floatingProps}`
`          {...propsRest}               -> // Added during refactoring. Just in case Floating UI starts stripping unknown props when spreading using getFloatingProps`
