### PR TITLE
PropertyList component to match design system requirements

### DIFF
--- a/src/components/lists/PropertyList/PropertyList.module.scss
+++ b/src/components/lists/PropertyList/PropertyList.module.scss
@@ -65,12 +65,10 @@
       @include bk.text-layout;
     }
 
-    /**
-      * This wrapper is the ONLY element that gets clamped.
-      * React will dynamically set:
-      * style={{ WebkitLineClamp: clampLines }}
-      */
-    .bk-property-list__property__clamped {
+    // This wrapper is the ONLY element that gets clamped.
+    // React will dynamically set:
+    // style={{ WebkitLineClamp: clampLines }}
+    .bk-property-list__property__value--clamped {
       display: -webkit-box;
       -webkit-box-orient: vertical;
       overflow: hidden;
@@ -78,11 +76,12 @@
 
     .bk-property-list__property__toggle-expand {
       align-self: flex-start;
+      cursor: pointer;
+      
       font-weight: bk.$font-weight-regular;
       font-size: bk.$font-size-m;
       color: bk.$theme-button-tertiary-text-default;
-      cursor: pointer;
-      text-decoration: none; // remove default underline
+      text-decoration: none; // Remove default underline
 
       &:hover {
         color: bk.$theme-button-tertiary-text-hover;

--- a/src/components/lists/PropertyList/PropertyList.stories.tsx
+++ b/src/components/lists/PropertyList/PropertyList.stories.tsx
@@ -5,21 +5,17 @@
 import * as React from 'react';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { loremIpsumParagraph } from '../../../util/storybook/LoremIpsum.tsx';
 
 import { PropertyList } from './PropertyList.tsx';
 
-import { loremIpsumParagraph } from '../../../util/storybook/LoremIpsum.tsx';
 
-/**
- * Merge PropertyList + Property props
- * but omit children from auto-control exposure
- */
-type PropertyListArgs =
-  Omit<React.ComponentProps<typeof PropertyList>, 'children'> &
-  React.ComponentProps<typeof PropertyList.Property> & {
-    children?: React.ReactNode;
+// Merge PropertyList + Property props, but omit children from auto-control exposure
+type PropertyListArgs = Omit<React.ComponentProps<typeof PropertyList>, 'children'>
+  & React.ComponentProps<typeof PropertyList.Property> & {
+    children?: React.ReactNode,
   };
-  
+
 const sizes = ['small', 'medium', 'large', 'full-size'] as const;
 
 type Story = StoryObj<PropertyListArgs>;
@@ -55,7 +51,6 @@ export default {
     children: {
       table: { disable: true },
     },
-
   },
 
   args: {
@@ -79,9 +74,7 @@ export default {
 
     return (
       <PropertyList orientation={orientation}>
-        {children ? (
-          children
-        ) : (
+        {children || (
           <>
             <PropertyList.Property
               label={label}
@@ -204,12 +197,12 @@ export const ManyProperties: Story = {
   args: {
     children: (
       <>
-        {Array.from({ length: 12 }).map((_, i) => {
+        {Array.from({ length: 12 }, (_, index) => index + 1).map(index => {
           return (
             <PropertyList.Property
-              key={i}
-              label={`Key ${i + 1}`}
-              value={`Value ${i + 1}`}
+              key={index}
+              label={`Key ${index + 1}`}
+              value={`Value ${index + 1}`}
             />
           );
         })}
@@ -222,14 +215,14 @@ export const ManyPropertiesWithDifferentRandomSizes: Story = {
   args: {
     children: (
       <>
-        {Array.from({ length: 12 }).map((_, i) => {
+        {Array.from({ length: 12 }, (_, index) => index + 1).map(index => {
           const size = sizes[Math.floor(Math.random() * sizes.length)];
 
           return (
             <PropertyList.Property
-              key={i}
-              label={`Key ${i + 1} (${size})`}
-              value={`Value ${i + 1}`}
+              key={index}
+              label={`Key ${index} (${size})`}
+              value={`Value ${index}`}
               size={size}
             />
           );

--- a/src/components/lists/PropertyList/PropertyList.tsx
+++ b/src/components/lists/PropertyList/PropertyList.tsx
@@ -86,7 +86,7 @@ export const Property = (props: PropertyProps) => {
           className={cx(
             cl['bk-property-list__property__value'],
             {
-              [cl['bk-property-list__property__clamped']]: shouldClamp,
+              [cl['bk-property-list__property__value--clamped']]: shouldClamp,
             },
           )}
           style={
@@ -100,7 +100,7 @@ export const Property = (props: PropertyProps) => {
 
         {expandable && isStringValue && (
           <ButtonAsLink
-            onPress={() => setToggleExpanded((prev) => !prev)}
+            onPress={() => { setToggleExpanded(prev => !prev); }}
             className={cl['bk-property-list__property__toggle-expand']}
           >
             {toggleExpanded ? 'View less' : 'View more'}


### PR DESCRIPTION
This PR introduces a new implementation of `PropertyList` and `Property` with built-in support for multi-line clamping and expandable values.

## Key Features

### Layout compatibility
- Supports both `horizontal` and `vertical` orientations.
- Allows property sizing via the `size` prop (`small`, `medium`, `large`, `full-width`).
- Uses flexible layout to automatically wrap properties across rows.

### Multi-line clamping (`expandable`)
- Supports configurable `clampLines` (default: `4`).
- Displays ellipsis (`...`) when content overflows.
- Adds a **“View more / View less”** toggle when content exceeds the clamp limit.

### Expand / Collapse behavior
- Expands or collapses the property value without affecting the surrounding layout.
- Toggle is self-contained within the `Property` component.

## Notes
- Clamping is only applied when `value` is a string.
- Layout remains responsive using flex wrapping.

## Example

```tsx
<PropertyList>
  <PropertyList.Property
    size="Large"
    label="Description"
    value={longText}
    expandable
    clampLines={3}
  />
</PropertyList>
```

<img width="800" height="389" alt="Screenshot 2026-03-06 at 5 53 44 PM" src="https://github.com/user-attachments/assets/eb34c54d-4ce4-4738-a6b0-e187c6dc9a94" />
<img width="773" height="727" alt="Screenshot 2026-03-06 at 5 53 54 PM" src="https://github.com/user-attachments/assets/7ff23c45-af7c-4f75-a37d-ac8527ac7a71" />
<img width="788" height="672" alt="Screenshot 2026-03-06 at 5 54 01 PM" src="https://github.com/user-attachments/assets/2372b191-8f93-4f0f-9049-971047f81040" />
<img width="783" height="248" alt="Screenshot 2026-03-06 at 5 54 09 PM" src="https://github.com/user-attachments/assets/16d68ee1-06b9-4471-883d-433f4662e4a2" />
<img width="780" height="299" alt="Screenshot 2026-03-06 at 5 54 13 PM" src="https://github.com/user-attachments/assets/0d74bc87-fb01-4cfb-a647-08b93505c90d" />
<img width="795" height="508" alt="Screenshot 2026-03-06 at 5 54 19 PM" src="https://github.com/user-attachments/assets/ab956276-853c-4241-9c2f-da9d4ce498e4" />
<img width="791" height="170" alt="Screenshot 2026-03-06 at 5 54 25 PM" src="https://github.com/user-attachments/assets/93ece282-e2a5-4a90-b568-2c8062afce1d" />
<img width="786" height="253" alt="Screenshot 2026-03-06 at 5 54 29 PM" src="https://github.com/user-attachments/assets/ff3c1c30-c9b9-494f-8ab0-152b27f9d039" />
<img width="785" height="503" alt="Screenshot 2026-03-06 at 5 54 36 PM" src="https://github.com/user-attachments/assets/ced29ab4-e692-4c07-9392-c5015f10024c" />
<img width="793" height="213" alt="Screenshot 2026-03-06 at 5 54 40 PM" src="https://github.com/user-attachments/assets/ced6806a-7cac-47d4-a6e7-9a1395871637" />
<img width="792" height="350" alt="Screenshot 2026-03-06 at 5 54 45 PM" src="https://github.com/user-attachments/assets/02cb23b4-1f21-4398-b0de-b29d9ea48619" />

