### PR TITLE
Includes one DialogOverlay story about imperative opening

### DIFF
--- a/src/components/overlays/DialogOverlay/DialogOverlay.stories.tsx
+++ b/src/components/overlays/DialogOverlay/DialogOverlay.stories.tsx
@@ -117,7 +117,7 @@ export const DialogOverlayWithToast: Story = {
 };
 
 const DialogOverlayControlledWithRef = (props: React.ComponentProps<typeof DialogOverlay>) => {
-  const ref = DialogOverlay.usePopoverRef();
+  const ref = DialogOverlay.usePopoverRef(null);
   
   // biome-ignore lint/correctness/useExhaustiveDependencies: want to only trigger this once
   React.useEffect(() => {


### PR DESCRIPTION
Adds a story to the `DialogOverlay` component, with it opening imperatively, similar to `DialogModal`

<img width="1920" height="898" alt="image" src="https://github.com/user-attachments/assets/0c3aff40-8db1-4472-a76c-eb35ccfc81f5" />
