### PR TITLE
fix(build): resolve dynamic require issue with React in `Vite` (`Rolldown`)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -104,7 +104,7 @@ export default defineConfig({
       //cssFileName: 'baklava',
       formats: ['es'],
     },
-    rollupOptions: {
+    rolldownOptions: {
       // Do not include React in the output (rely on the consumer to bring their own version)
       // external: ['react', 'react/jsx-runtime'],
       plugins: [


### PR DESCRIPTION
This PR resolves a runtime error encountered when consuming the library in a Vite-based application:
`Uncaught Error: Calling `require` for "react" in an environment that doesn't expose the `require` function`

Applied the recommended workaround from the Rolldown issue to ensure proper handling of external React dependencies.

Ensured the library outputs a pure ESM-compatible bundle without any require() calls.

Verified compatibility by installing and testing the library locally in a alton.

Reference: https://github.com/vitejs/rolldown-vite/issues/596
