### PR TITLE
Fire callback when DialogOverlay is closing via Esc or click outside

### DIFF
--- a/src/components/overlays/DialogOverlay/DialogOverlay.stories.tsx
+++ b/src/components/overlays/DialogOverlay/DialogOverlay.stories.tsx
@@ -115,3 +115,11 @@ export const DialogOverlayWithToast: Story = {
     ),
   },
 };
+
+export const DialogOverlayProviderPropsOnRequestClose: Story = {
+  args: {
+    providerProps: {
+      onRequestClose: () => { notify.info('providerProps onRequestClose'); },
+    },
+  },  
+};

--- a/src/components/overlays/DialogOverlay/DialogOverlay.tsx
+++ b/src/components/overlays/DialogOverlay/DialogOverlay.tsx
@@ -49,7 +49,7 @@ export type DialogOverlayProps = Omit<React.ComponentProps<typeof Dialog>, 'chil
   popoverRef?: undefined | React.Ref<React.ComponentRef<typeof PopoverProvider>>,
   
   /** Any additional props to pass to the popover provider. */
-  providerProps?: undefined | Omit<PopoverProviderPropsDialog, 'children'>,
+  providerProps?: undefined | Omit<PopoverProviderPropsDialog, 'children' | 'popover'>,
 };
 
 export type OverlayWithSubject<S> = {

--- a/src/components/util/overlays/popover/PopoverProvider.tsx
+++ b/src/components/util/overlays/popover/PopoverProvider.tsx
@@ -13,6 +13,7 @@ export type PopoverRef = {
   active: boolean,
   activate: () => void,
   deactivate: () => void,
+  onlyDeactivate: () => void,
 };
 
 export type PopoverParams<E extends HTMLElement> = UsePopoverResult<E> & {
@@ -41,6 +42,9 @@ export type PopoverProviderProps<E extends HTMLElement> = {
   
   /** How long to keep the popover in the DOM for exit animation purposes. Default: 3 seconds. */
   unmountDelay?: undefined | number,
+  
+  /** A callback function that is executed when the PopoverOverlay children (i.e. DialogOverlay) is closing. */
+  onRequestClose?: undefined | (() => void | Promise<void>),
 };
 /**
  * Provider around a trigger (e.g. button) to display a popover overlay on trigger activation.
@@ -64,13 +68,16 @@ export const PopoverProvider = Object.assign(
       //source, // TODO: need a reference to the trigger element
       active: active,
       activate: () => { setActiveWithDelay(true); },
-      deactivate: () => { setActiveWithDelay(false); },
+      // we don't want to call props.onRequestClose() when we're closing on our end (X button or Cancel)
+      // otherwise it will fire twice
+      onlyDeactivate: () => { setActiveWithDelay(false); },
+      deactivate: () => { setActiveWithDelay(false); props.onRequestClose?.(); },
     }), [active, setActiveWithDelay]);
     
     React.useImperativeHandle(ref, () => popoverRef, [popoverRef]);
     
     const popoverParams = Object.assign(usePopover<E>(popoverRef), {
-      close: popoverRef.deactivate,
+      close: popoverRef.onlyDeactivate,
     });
     
     // Track this as part of our top layer elements tracker


### PR DESCRIPTION
Gets the job done, but I'm not sure it's the most elegant way. Maybe I am adding a workaround for something that should be fixed elsewhere?

Closes #638 

https://github.com/user-attachments/assets/6e6e8b01-0be8-42fc-92c1-721164a9604b


