### PR TITLE
Fixed global filtering behavior when no filterable columns are present on `DataTableEager`

### DIFF
--- a/src/components/tables/DataTable/DataTableEager.stories.tsx
+++ b/src/components/tables/DataTable/DataTableEager.stories.tsx
@@ -579,7 +579,9 @@ export const DataTableEagerWithPageLayoutEdgeCases: StoryObj<typeof DataTableEag
 
 const useTableModal = () => {
   const modal = DialogModal.useModalRef();
-
+  const childTableColumns = [
+    ...columns.map(({ disableGlobalFilter, ...rest }) => rest), // remove the key disableGlobalFilter & append columns
+  ]
   return {
     activate() {
       modal.current?.activate();
@@ -593,7 +595,7 @@ const useTableModal = () => {
         >
           <Panel>
             <DataTableEager.TableProviderEager
-              columns={columns}
+              columns={childTableColumns}
               items={generateData({ numItems: 2 })}
               getRowId={(item: User) => item.id}
               plugins={[DataTablePlugins.useRowSelectColumn]}
@@ -618,10 +620,8 @@ export const DataTableEagerWithEdit: Story = {
       {
         id: 'actions',
         Header: 'Actions',
-        disableSortBy: true,
         Cell: () => (
           <>
-            {dataTableModal.render()}
             <IconButton
               icon="edit"
               label="edit"
@@ -635,12 +635,14 @@ export const DataTableEagerWithEdit: Story = {
 
     return (
       <Panel>
+        {dataTableModal.render()}
         <DataTableEager.TableProviderEager
           columns={tableCol}
           items={data}
           getRowId={(row: User) => row.id}
           plugins={[DataTablePlugins.useRowSelectColumn]}
         >
+          <DataTableEager.Search />
           <DataTableEager.DataTableEager />
         </DataTableEager.TableProviderEager>
       </Panel>

--- a/src/components/tables/DataTable/DataTableEager.stories.tsx
+++ b/src/components/tables/DataTable/DataTableEager.stories.tsx
@@ -17,6 +17,7 @@ import * as Filtering from './filtering/Filtering.ts';
 import type { Fields, FilterQuery } from '../MultiSearch/filterQuery.ts';
 
 import { Button } from '../../actions/Button/Button.tsx';
+import { IconButton } from '../../actions/IconButton/IconButton.tsx';
 import { DialogModal } from '../../overlays/DialogModal/DialogModal.tsx';
 import { PageLayout } from '../../../layouts/PageLayout/PageLayout.tsx';
 import { Panel } from '../../containers/Panel/Panel.tsx';
@@ -574,4 +575,75 @@ export const DataTableEagerWithPageLayoutEdgeCases: StoryObj<typeof DataTableEag
       </PageLayout>
     ),
   ],
+};
+
+const useTableModal = () => {
+  const modal = DialogModal.useModalRef();
+
+  return {
+    activate() {
+      modal.current?.activate();
+    },
+    render() {
+      return (
+        <DialogModal
+          modalRef={modal}
+          title="Modal Edit"
+          size="large"
+        >
+          <Panel>
+            <DataTableEager.TableProviderEager
+              columns={columns}
+              items={generateData({ numItems: 2 })}
+              getRowId={(item: User) => item.id}
+              plugins={[DataTablePlugins.useRowSelectColumn]}
+            >
+              <DataTableEager.DataTableEager />
+            </DataTableEager.TableProviderEager>
+          </Panel>
+        </DialogModal>
+      );
+    },
+  };
+};
+
+export const DataTableEagerWithEdit: Story = {
+  render: () => {
+
+    const data = generateData({ numItems: 7 });
+    const dataTableModal = useTableModal();
+
+    const tableCol = [
+      ...columns,
+      {
+        id: 'actions',
+        Header: 'Actions',
+        disableSortBy: true,
+        Cell: () => (
+          <>
+            {dataTableModal.render()}
+            <IconButton
+              icon="edit"
+              label="edit"
+              onPress={() => {
+                dataTableModal.activate();
+              }}
+            />
+          </>)
+      },
+    ];
+
+    return (
+      <Panel>
+        <DataTableEager.TableProviderEager
+          columns={tableCol}
+          items={data}
+          getRowId={(row: User) => row.id}
+          plugins={[DataTablePlugins.useRowSelectColumn]}
+        >
+          <DataTableEager.DataTableEager />
+        </DataTableEager.TableProviderEager>
+      </Panel>
+    );
+  },
 };

--- a/src/components/tables/DataTable/DataTableEager.tsx
+++ b/src/components/tables/DataTable/DataTableEager.tsx
@@ -18,6 +18,49 @@ export * from './DataTableContext.tsx';
 export { Pagination };
 export { DataTablePlaceholderEmpty, DataTablePlaceholderError } from './table/DataTablePlaceholder.tsx';
 
+/**
+ * Custom global filter for react-table.
+ *
+ * Handles:
+ * - Empty search (returns all rows)
+ * - No filterable columns (returns all rows)
+ * - Safe comparison for null/undefined/non-string values
+ * - Case-insensitive partial matching across all columns
+ */
+const customGlobalFilter: ReactTable.FilterType<D> = (
+  rows: ReactTable.Row<D>[], // All rows before filtering
+  columnIds: string[], // IDs of columns allowed for global filtering
+  filterValue: unknown // Value from global search input
+) => {
+  // Normalize the search input:
+  // - Convert to string
+  // - Handle null/undefined safely
+  // - Make it case-insensitive
+  const search = String(filterValue ?? '').toLowerCase();
+
+  // If search is empty → do not filter, return all rows
+  // Prevents "empty table on initial load" issue
+  if (!search) return rows;
+
+  // If no columns are filterable → skip filtering
+  // Prevents react-table from returning empty results
+  // when all columns have `disableGlobalFilter: true`
+  if (!columnIds.length) return rows;
+
+  // Filter rows:
+  // Include a row if ANY filterable column matches the search value
+  return rows.filter(row =>
+    columnIds.some(id => {
+      const value = row.values[id]; // Get the cell value for the column
+      // Convert value safely to string and compare
+      // - Handles null/undefined
+      // - Supports numbers, booleans, etc.
+      return String(value ?? '')
+        .toLowerCase()
+        .includes(search); // Partial match
+    })
+  );
+};
 
 interface ReactTableOptions<D extends object> extends ReactTable.TableOptions<D> {
   // Add custom properties here
@@ -56,10 +99,6 @@ export const TableProviderEager = <D extends object>(props: TableProviderEagerPr
     ...(isRowSelectDisabled ? { isRowSelectDisabled } : {}),
   };
   
-  const hasFilterableColumn = React.useMemo(() => {
-    return columns.some(col => col.disableGlobalFilter === false);
-  }, [columns]);
-  
   const table = ReactTable.useTable(
     {
       ...tableOptions,
@@ -85,8 +124,8 @@ export const TableProviderEager = <D extends object>(props: TableProviderEagerPr
         ...initialState,
       },
       
-      // useGlobalFilter only enable filtering when columns are available to filter
-      manualGlobalFilter: !hasFilterableColumn,
+      // useGlobalFilter
+      globalFilter: customGlobalFilter,
       
       // useSortBy
       disableSortRemove: true,

--- a/src/components/tables/DataTable/DataTableEager.tsx
+++ b/src/components/tables/DataTable/DataTableEager.tsx
@@ -27,39 +27,41 @@ export { DataTablePlaceholderEmpty, DataTablePlaceholderError } from './table/Da
  * - Safe comparison for null/undefined/non-string values
  * - Case-insensitive partial matching across all columns
  */
-const customGlobalFilter: ReactTable.FilterType<D> = (
-  rows: ReactTable.Row<D>[], // All rows before filtering
-  columnIds: string[], // IDs of columns allowed for global filtering
-  filterValue: unknown // Value from global search input
-) => {
-  // Normalize the search input:
-  // - Convert to string
-  // - Handle null/undefined safely
-  // - Make it case-insensitive
-  const search = String(filterValue ?? '').toLowerCase();
+const customGlobalFilter = <D extends object>(): ReactTable.FilterType<D> => {
+  return (
+    rows: ReactTable.Row<D>[], // All rows before filtering
+    columnIds: string[], // IDs of columns allowed for global filtering
+    filterValue: ReactTable.Row<D>[], // Value from global search input
+  ) => {
+    // Normalize the search input:
+    // - Convert to string
+    // - Handle null/undefined safely
+    // - Make it case-insensitive
+    const search = String(filterValue ?? '').toLowerCase();
 
-  // If search is empty → do not filter, return all rows
-  // Prevents "empty table on initial load" issue
-  if (!search) return rows;
+    // If search is empty → do not filter, return all rows
+    // Prevents "empty table on initial load" issue
+    if (!search) return rows;
 
-  // If no columns are filterable → skip filtering
-  // Prevents react-table from returning empty results
-  // when all columns have `disableGlobalFilter: true`
-  if (!columnIds.length) return rows;
+    // If no columns are filterable → skip filtering
+    // Prevents react-table from returning empty results
+    // when all columns have `disableGlobalFilter: true`
+    if (!columnIds.length) return rows;
 
-  // Filter rows:
-  // Include a row if ANY filterable column matches the search value
-  return rows.filter(row =>
-    columnIds.some(id => {
-      const value = row.values[id]; // Get the cell value for the column
-      // Convert value safely to string and compare
-      // - Handles null/undefined
-      // - Supports numbers, booleans, etc.
-      return String(value ?? '')
-        .toLowerCase()
-        .includes(search); // Partial match
-    })
-  );
+    // Filter rows:
+    // Include a row if ANY filterable column matches the search value
+    return rows.filter(row =>
+      columnIds.some(id => {
+        const value = row.values[id]; // Get the cell value for the column
+        // Convert value safely to string and compare
+        // - Handles null/undefined
+        // - Supports numbers, booleans, etc.
+        return String(value ?? '')
+          .toLowerCase()
+          .includes(search); // Partial match
+      })
+    );
+  }
 };
 
 interface ReactTableOptions<D extends object> extends ReactTable.TableOptions<D> {
@@ -125,7 +127,7 @@ export const TableProviderEager = <D extends object>(props: TableProviderEagerPr
       },
       
       // useGlobalFilter
-      globalFilter: customGlobalFilter,
+      globalFilter: customGlobalFilter<D>(),
       
       // useSortBy
       disableSortRemove: true,

--- a/src/components/tables/DataTable/DataTableEager.tsx
+++ b/src/components/tables/DataTable/DataTableEager.tsx
@@ -82,7 +82,7 @@ export const TableProviderEager = <D extends object>(props: TableProviderEagerPr
       },
       
       // useGlobalFilter
-      manualGlobalFilter: false,
+      manualGlobalFilter: true,
       
       // useSortBy
       disableSortRemove: true,

--- a/src/components/tables/DataTable/DataTableEager.tsx
+++ b/src/components/tables/DataTable/DataTableEager.tsx
@@ -11,6 +11,7 @@ import { type TableContextState, createTableContext, useTable } from './DataTabl
 import { Pagination } from './pagination/Pagination.tsx';
 import { MultiSearch as MultiSearchInput } from '../MultiSearch/MultiSearch.tsx';
 import { DataTableSync, type DataTableSyncProps } from './table/DataTable.tsx';
+import { removeCombiningCharacters } from '../../../util/formatting.ts';
 
 import cl from './DataTableEager.module.scss';
 
@@ -37,7 +38,7 @@ const customGlobalFilter = <D extends object>(): ReactTable.FilterType<D> => {
     // - Convert to string
     // - Handle null/undefined safely
     // - Make it case-insensitive
-    const search = String(filterValue ?? '').toLowerCase();
+    const search = removeCombiningCharacters(String(filterValue ?? '')).toLowerCase();
 
     // If search is empty → do not filter, return all rows
     // Prevents "empty table on initial load" issue
@@ -60,7 +61,7 @@ const customGlobalFilter = <D extends object>(): ReactTable.FilterType<D> => {
         // Convert value safely to string and compare
         // - Handles null/undefined
         // - Supports numbers, booleans, etc.
-        return String(value ?? '')
+        return removeCombiningCharacters(String(value ?? ''))
           .toLowerCase()
           .includes(search); // Partial match
       })

--- a/src/components/tables/DataTable/DataTableEager.tsx
+++ b/src/components/tables/DataTable/DataTableEager.tsx
@@ -55,7 +55,11 @@ export const TableProviderEager = <D extends object>(props: TableProviderEagerPr
     ...(stickyColumns ? { bkStickyColumns: stickyColumns } : {}),
     ...(isRowSelectDisabled ? { isRowSelectDisabled } : {}),
   };
-
+  
+  const hasFilterableColumn = React.useMemo(() => {
+    return columns.some(col => col.disableGlobalFilter === false);
+  }, [columns]);
+  
   const table = ReactTable.useTable(
     {
       ...tableOptions,
@@ -81,8 +85,8 @@ export const TableProviderEager = <D extends object>(props: TableProviderEagerPr
         ...initialState,
       },
       
-      // useGlobalFilter
-      manualGlobalFilter: true,
+      // useGlobalFilter only enable filtering when columns are available to filter
+      manualGlobalFilter: !hasFilterableColumn,
       
       // useSortBy
       disableSortRemove: true,

--- a/src/components/tables/DataTable/DataTableEager.tsx
+++ b/src/components/tables/DataTable/DataTableEager.tsx
@@ -29,9 +29,9 @@ export { DataTablePlaceholderEmpty, DataTablePlaceholderError } from './table/Da
  */
 const customGlobalFilter = <D extends object>(): ReactTable.FilterType<D> => {
   return (
-    rows: ReactTable.Row<D>[], // All rows before filtering
+    rows: Array<ReactTable.Row<D>>, // All rows before filtering
     columnIds: string[], // IDs of columns allowed for global filtering
-    filterValue: ReactTable.Row<D>[], // Value from global search input
+    filterValue: Array<ReactTable.Row<D>>, // Value from global search input
   ) => {
     // Normalize the search input:
     // - Convert to string
@@ -41,12 +41,16 @@ const customGlobalFilter = <D extends object>(): ReactTable.FilterType<D> => {
 
     // If search is empty → do not filter, return all rows
     // Prevents "empty table on initial load" issue
-    if (!search) return rows;
+    if (!search) {
+      return rows;
+    }
 
     // If no columns are filterable → skip filtering
     // Prevents react-table from returning empty results
     // when all columns have `disableGlobalFilter: true`
-    if (!columnIds.length) return rows;
+    if (!columnIds.length) {
+      return rows;
+    }
 
     // Filter rows:
     // Include a row if ANY filterable column matches the search value

--- a/src/components/tables/DataTable/DataTableEager.tsx
+++ b/src/components/tables/DataTable/DataTableEager.tsx
@@ -57,7 +57,7 @@ export const TableProviderEager = <D extends object>(props: TableProviderEagerPr
   };
   
   const hasFilterableColumn = React.useMemo(() => {
-    return columns.some(col => col.disableGlobalFilter === false);
+    return !columns.some(col => col.disableGlobalFilter === false);
   }, [columns]);
   
   const table = ReactTable.useTable(
@@ -86,7 +86,7 @@ export const TableProviderEager = <D extends object>(props: TableProviderEagerPr
       },
       
       // useGlobalFilter only enable filtering when columns are available to filter
-      manualGlobalFilter: !hasFilterableColumn,
+      manualGlobalFilter: hasFilterableColumn,
       
       // useSortBy
       disableSortRemove: true,

--- a/src/components/tables/DataTable/DataTableEager.tsx
+++ b/src/components/tables/DataTable/DataTableEager.tsx
@@ -57,7 +57,7 @@ export const TableProviderEager = <D extends object>(props: TableProviderEagerPr
   };
   
   const hasFilterableColumn = React.useMemo(() => {
-    return !columns.some(col => col.disableGlobalFilter === false);
+    return columns.some(col => col.disableGlobalFilter === false);
   }, [columns]);
   
   const table = ReactTable.useTable(
@@ -86,7 +86,7 @@ export const TableProviderEager = <D extends object>(props: TableProviderEagerPr
       },
       
       // useGlobalFilter only enable filtering when columns are available to filter
-      manualGlobalFilter: hasFilterableColumn,
+      manualGlobalFilter: !hasFilterableColumn,
       
       // useSortBy
       disableSortRemove: true,


### PR DESCRIPTION
This PR contains a fix for #643 

This change ensures that `customGlobalFilter` is only enabled when at least one column explicitly allows it.

Previously, global filtering was always active, even when all columns had `disableGlobalFilter: true`  or `disableGlobalFilter: undefined`. This caused the filtering pipeline to run without any eligible columns, resulting in all rows being filtered out and the table appearing empty.


**Changes**
- Added `customGlobalFilter`:

**Before**
- Global filter always applied
- No filterable columns → table rendered empty

**After**
- Global filter runs only when valid columns exist
- No filterable columns → data renders normally