### PR TITLE
`DialogModal`: properly merge `onClose` props

### DIFF
--- a/src/components/containers/Dialog/Dialog.stories.tsx
+++ b/src/components/containers/Dialog/Dialog.stories.tsx
@@ -7,6 +7,8 @@ import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { LayoutDecorator } from '../../../util/storybook/LayoutDecorator.tsx';
 import { loremIpsum, LoremIpsum, loremIpsumSentence } from '../../../util/storybook/LoremIpsum.tsx';
+
+import { notify } from '../../overlays/ToastProvider/ToastProvider.tsx';
 import { Form } from '../../forms/context/Form/Form.tsx';
 import { FormLayout } from '../../../layouts/FormLayout/FormLayout.tsx';
 import { RadioGroup } from '../../forms/controls/RadioGroup/RadioGroup.tsx';
@@ -114,6 +116,24 @@ export const DialogWithTitleOverflow: Story = {
 export const DialogFlat: Story = {
   args: {
     flat: true,
+  },
+};
+
+/**
+ * When the user clicks on either the "Close" or "Submit" action, or the "X" close button, the `onRequestClose`
+ * callback should get triggered. The "Test" action here should not trigger `onRequestClose`.
+ */
+export const DialogWithOnRequestClose: Story = {
+  args: {
+    onRequestClose: () => { notify.info('User requested close'); },
+    showCancelAction: false,
+    actions: (
+      <>
+        <Dialog.CancelAction/>
+        <Dialog.SubmitAction/>
+        <Dialog.Action label="Test"/>
+      </>
+    ),
   },
 };
 

--- a/src/components/containers/Dialog/Dialog.tsx
+++ b/src/components/containers/Dialog/Dialog.tsx
@@ -138,7 +138,7 @@ export const Dialog = Object.assign(
     }
     
     const dialogContext = React.useMemo<DialogContext>(() => ({
-      close: onRequestClose ?? (() => { console.warn('Missing `onRequestClose` callback.'); })
+      close: onRequestClose ?? (() => { console.warn('Missing `onRequestClose` callback.'); }),
     }), [onRequestClose]);
     
     const handleClose = React.useCallback((event: React.SyntheticEvent<HTMLDialogElement>) => {

--- a/src/components/overlays/DialogModal/DialogModal.stories.tsx
+++ b/src/components/overlays/DialogModal/DialogModal.stories.tsx
@@ -143,6 +143,13 @@ export const DialogModalSlideOverLeft: Story = {
   },
 };
 
+export const DialogWithOnClose: Story = {
+  args: {
+    title: 'Modal with a close handler',
+    onClose: () => { notify.info('The DialogModal was closed'); },
+  },
+};
+
 export const DialogModalNested: Story = {
   args: {
     title: 'Modal with a submodal',

--- a/src/components/overlays/DialogModal/DialogModal.stories.tsx
+++ b/src/components/overlays/DialogModal/DialogModal.stories.tsx
@@ -143,7 +143,7 @@ export const DialogModalSlideOverLeft: Story = {
   },
 };
 
-export const DialogWithOnClose: Story = {
+export const DialogModalWithOnClose: Story = {
   args: {
     title: 'Modal with a close handler',
     onClose: () => { notify.info('The DialogModal was closed'); },

--- a/src/components/overlays/DialogModal/DialogModal.tsx
+++ b/src/components/overlays/DialogModal/DialogModal.tsx
@@ -17,7 +17,7 @@ import cl from './DialogModal.module.scss';
 
 export { cl as DialogModalClassNames };
 
-export type DialogModalProps = Omit<React.ComponentProps<typeof Dialog>, 'children'> & {
+export type DialogModalProps = Omit<React.ComponentProps<typeof Dialog>, 'children' | 'onRequestClose'> & {
   /** Content of the modal. If a function, will be passed a dialog controller. */
   children?: React.ReactNode | ModalProviderProps['dialog'],
   
@@ -201,8 +201,8 @@ export const DialogModal = Object.assign(
             showCloseIcon={allowUserClose}
             autoFocusClose={allowUserClose}
             showCancelAction={allowUserClose}
-            onRequestClose={dialogController.close}
             {...propsRest}
+            onRequestClose={dialogController.close}
             className={cx(
               'bk',
               { [cl['bk-dialog-modal']]: !unstyled },

--- a/src/components/overlays/DialogModal/DialogModal.tsx
+++ b/src/components/overlays/DialogModal/DialogModal.tsx
@@ -6,7 +6,7 @@ import type { NonUndefined } from '../../../util/types.ts';
 
 import * as React from 'react';
 import { flushSync } from 'react-dom';
-import { mergeCallbacks, mergeRefs } from '../../../util/reactUtil.ts';
+import { mergeCallbacks, mergeRefs, mergeProps } from '../../../util/reactUtil.ts';
 import { classNames as cx } from '../../../util/componentUtil.ts';
 
 import { Dialog } from '../../containers/Dialog/Dialog.tsx';
@@ -174,6 +174,7 @@ export const DialogModal = Object.assign(
   (props: DialogModalProps) => {
     const {
       children,
+      title,
       unstyled = false,
       activeDefault = false,
       display = 'center',
@@ -187,6 +188,9 @@ export const DialogModal = Object.assign(
       ...propsRest
     } = props;
     
+    // Need to omit `title` from the merged props since it's incompatible between `HTMLDialogElement` and `DialogModal`
+    type DialogPropsMerged = Array<Omit<React.ComponentProps<typeof Dialog>, 'title'>>;
+    
     return (
       <ModalProvider
         activeDefault={activeDefault}
@@ -196,12 +200,12 @@ export const DialogModal = Object.assign(
         dialog={dialogController =>
           <Dialog
             aria-modal="true"
+            title={title}
             flat={['slide-over'].includes(display)}
-            {...dialogController.dialogProps}
             showCloseIcon={allowUserClose}
             autoFocusClose={allowUserClose}
             showCancelAction={allowUserClose}
-            {...propsRest}
+            {...mergeProps<DialogPropsMerged>(dialogController.dialogProps, propsRest)}
             onRequestClose={dialogController.close}
             className={cx(
               'bk',

--- a/src/components/overlays/DialogModal/DialogModal.tsx
+++ b/src/components/overlays/DialogModal/DialogModal.tsx
@@ -6,7 +6,7 @@ import type { NonUndefined } from '../../../util/types.ts';
 
 import * as React from 'react';
 import { flushSync } from 'react-dom';
-import { mergeCallbacks, mergeRefs, mergeProps } from '../../../util/reactUtil.ts';
+import { mergeCallbacks, mergeProps, mergeRefs } from '../../../util/reactUtil.ts';
 import { classNames as cx } from '../../../util/componentUtil.ts';
 
 import { Dialog } from '../../containers/Dialog/Dialog.tsx';

--- a/src/components/overlays/DialogOverlay/DialogOverlay.stories.tsx
+++ b/src/components/overlays/DialogOverlay/DialogOverlay.stories.tsx
@@ -10,6 +10,7 @@ import { LoremIpsum } from '../../../util/storybook/LoremIpsum.tsx';
 import { notify } from '../ToastProvider/ToastProvider.tsx';
 import { DialogModal } from '../DialogModal/DialogModal.tsx';
 import { Button } from '../../actions/Button/Button.tsx';
+import { Prose } from '../../../typography/Prose/Prose.tsx';
 import { TooltipProvider } from '../Tooltip/TooltipProvider.tsx';
 
 import { DialogOverlay } from './DialogOverlay.tsx';
@@ -113,5 +114,29 @@ export const DialogOverlayWithToast: Story = {
         onPress={() => notify.info('This notification should be above the overlay.', { autoClose: false })}
       />
     ),
+  },
+};
+
+export const DialogOverlayWithOnToggle: Story = {
+  args: {
+    title: 'Overlay with a toggle handler',
+    children: (
+      <Prose>
+        <p>Notice that the DialogOverlay uses a <code>popover</code>, not a <code>dialog</code>.</p>
+        <p>
+          Thus it doesn't have <code>onClose</code> and <code>onOpen</code>, only <code>onToggle</code>,
+          and you need to control the state you want to react to, by looking at <code>event.newState</code> if
+          it's <code>open</code> or <code>closed</code>.
+        </p>
+      </Prose>
+    ),
+    onToggle: (event) => {
+      if (event.newState === 'closed') {
+        notify.info('DialogOverlay closed');
+      }
+      if (event.newState === 'open') {
+        notify.info('DialogOverlay opened');
+      }
+    },
   },
 };

--- a/src/components/overlays/DialogOverlay/DialogOverlay.stories.tsx
+++ b/src/components/overlays/DialogOverlay/DialogOverlay.stories.tsx
@@ -124,9 +124,9 @@ export const DialogOverlayWithOnToggle: Story = {
       <Prose>
         <p>Notice that the DialogOverlay uses a <code>popover</code>, not a <code>dialog</code>.</p>
         <p>
-          Thus it doesn't have <code>onClose</code> and <code>onOpen</code>, only <code>onToggle</code>,
-          and you need to control the state you want to react to, by looking at <code>event.newState</code> if
-          it's <code>open</code> or <code>closed</code>.
+          Thus, if you want to listen to changes in <code>popover</code> state, use <code>onToggle</code>.
+          You can use <code>event.newState</code> to check the new state of the popover,
+          either <code>open</code> or <code>closed</code>.
         </p>
       </Prose>
     ),

--- a/src/components/overlays/DialogOverlay/DialogOverlay.tsx
+++ b/src/components/overlays/DialogOverlay/DialogOverlay.tsx
@@ -4,7 +4,7 @@
 
 import * as React from 'react';
 import { flushSync } from 'react-dom';
-import { mergeRefs } from '../../../util/reactUtil.ts';
+import { mergeProps, mergeRefs } from '../../../util/reactUtil.ts';
 import { classNames as cx } from '../../../util/componentUtil.ts';
 
 import { Dialog } from '../../containers/Dialog/Dialog.tsx';
@@ -91,6 +91,7 @@ export const DialogOverlay = Object.assign(
   (props: DialogOverlayProps) => {
     const {
       children,
+      title,
       unstyled = false,
       activeDefault = false,
       display = 'slide-over',
@@ -103,19 +104,25 @@ export const DialogOverlay = Object.assign(
       ...propsRest
     } = props;
     
+    // Need to omit `title` from the merged props since it's incompatible between `HTMLDialogElement` and `DialogModal`
+    // We also omit `onClose` because `popover` only supports `onToggle`
+    // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/toggle_event
+    type DialogPropsMerged = Array<Omit<React.ComponentProps<typeof Dialog>, 'title' | 'onClose'>>;
+    
     return (
       <PopoverProvider<HTMLDialogElement>
         activeDefault={activeDefault}
-        popover={popoverController =>
+        popover={popoverController => (
           <Dialog
+            title={title}
             open={false} // Make sure `open` is not set to avoid https://issues.chromium.org/issues/388538944
             flat={['slide-over'].includes(display)}
-            {...popoverController.popoverProps}
             showCloseIcon={allowUserClose}
             autoFocusClose={allowUserClose}
             showCancelAction={allowUserClose}
+            {...mergeProps<DialogPropsMerged>(popoverController.popoverProps, propsRest)}
             onRequestClose={popoverController.close}
-            {...propsRest}
+            onClose={undefined}
             className={cx(
               'bk',
               { [cl['bk-dialog-overlay']]: !unstyled },
@@ -131,7 +138,7 @@ export const DialogOverlay = Object.assign(
           >
             {typeof children === 'function' ? children(popoverController) : children}
           </Dialog>
-        }
+        )}
         {...providerProps}
         ref={mergeRefs(popoverRef, providerProps?.ref)}
       >

--- a/src/components/overlays/DialogOverlay/DialogOverlay.tsx
+++ b/src/components/overlays/DialogOverlay/DialogOverlay.tsx
@@ -17,7 +17,9 @@ export { cl as DialogOverlayClassNames };
 
 type PopoverProviderPropsDialog = PopoverProviderProps<HTMLDialogElement>;
 
-export type DialogOverlayProps = Omit<React.ComponentProps<typeof Dialog>, 'children'> & {
+// Need to omit `onClose` because `popover` only supports `onToggle`
+// https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/toggle_event
+export type DialogOverlayProps = Omit<React.ComponentProps<typeof Dialog>, 'children' | 'onClose'> & {
   /** Content of the overlay. If a function, will be passed a dialog controller. */
   children?: React.ReactNode | PopoverProviderPropsDialog['popover'],
   
@@ -105,9 +107,7 @@ export const DialogOverlay = Object.assign(
     } = props;
     
     // Need to omit `title` from the merged props since it's incompatible between `HTMLDialogElement` and `DialogModal`
-    // We also omit `onClose` because `popover` only supports `onToggle`
-    // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/toggle_event
-    type DialogPropsMerged = Array<Omit<React.ComponentProps<typeof Dialog>, 'title' | 'onClose'>>;
+    type DialogPropsMerged = Array<Omit<React.ComponentProps<typeof Dialog>, 'title'>>;
     
     return (
       <PopoverProvider<HTMLDialogElement>

--- a/src/components/util/overlays/modal/useModalDialog.ts
+++ b/src/components/util/overlays/modal/useModalDialog.ts
@@ -29,7 +29,7 @@ export type UseModalDialogOptions = {
 export type ModalDialogProps = {
   internalDialogRef: React.RefObject<null | HTMLDialogElement>,
   close: () => void,
-  dialogProps: React.ComponentProps<'dialog'>,
+  dialogProps: Omit<React.ComponentProps<'dialog'>, 'title'>,
 };
 
 /*


### PR DESCRIPTION
This PR fixes consumer-provided `onClose` on `DialogModal`, as well as `onToggle` on `DialogOverlay`. Previously, this would cause issues because the `onClose`/`onToggle` would override the internal dialog/popover state synchronization.

Resolves #638 
Resolves #639