### PR TITLE
CSS reset regressions: fix `draggable` attribute in WebKit-based browsers + `::marker` issue in Safari

### DIFF
--- a/src/styling/global/reset.scss
+++ b/src/styling/global/reset.scss
@@ -89,7 +89,7 @@ Notes:
     /* stylelint-enable property-no-deprecated */
     
     /* Needed for `[draggable]` */
-    -webkit-user-drag: revert;
+    -webkit-user-drag: revert-layer; /* `revert` doesn't work in Chromium? Possibly a bug? */
   }
   
   /* Enforce the `hidden` attribute. */

--- a/src/styling/global/reset.scss
+++ b/src/styling/global/reset.scss
@@ -194,7 +194,8 @@ Notes:
   longer be announced as a list. Instead, just set it to use an empty marker.
   */
   ol, ul, menu, summary {
-    list-style: '';
+    /*list-style: ''; FIXME: causes an issue in Safari where the `::marker` takes up space, e.g. sidebar items */
+    list-style: none;
   }
   ol {
     /* Retain the proper `counter-reset` behavior for nested lists. */


### PR DESCRIPTION
Fixes a few regressions from #610.

This PR:
- Fixes a regression in WebKit/Chromium browsers affecting elements with the `draggable` attribute, due to the CSS `-webkit-user-drag: revert` not working as expected for some reason (possibly a browser bug?).
- Fixes an issue in Safari where sidebar links would have additional spacing between each item due to the `::marker` taking up space despite having empty content.