### PR TITLE
Update page index indicator when changing page size

### DIFF
--- a/src/components/tables/DataTable/pagination/Pagination.tsx
+++ b/src/components/tables/DataTable/pagination/Pagination.tsx
@@ -47,7 +47,7 @@ export const Pagination = ({ pageSizeOptions }: PaginationProps) => {
   
   return (
     <div className={cx(cl['bk-pagination'])}>
-      <PaginationSizeSelector pageSizeOptions={pageSizeOptions} />
+      <PaginationSizeSelector pageSizeOptions={pageSizeOptions} setPageIndexIndicator={setPageIndexIndicator}/>
       
       <div className={cx(cl['pager'], cl['pager--indexed'])}>
         <IconButton

--- a/src/components/tables/DataTable/pagination/Pagination.tsx
+++ b/src/components/tables/DataTable/pagination/Pagination.tsx
@@ -18,6 +18,7 @@ import cl from './Pagination.module.scss';
 
 
 const parsePageNumber = (pageBuffer: string, max: number): null | number => {
+  if (pageBuffer.trim() === '') { return null; }
   const num = Math.floor(Number(pageBuffer));
   if (!Number.isFinite(num)) { return null; }
   if (!Number.isSafeInteger(num)) { return null; }

--- a/src/components/tables/DataTable/pagination/Pagination.tsx
+++ b/src/components/tables/DataTable/pagination/Pagination.tsx
@@ -17,12 +17,21 @@ import { useTable } from '../DataTableContext.tsx';
 import cl from './Pagination.module.scss';
 
 
+const parsePageNumber = (pageBuffer: string, max: number): null | number => {
+  const num = Math.floor(Number(pageBuffer));
+  if (!Number.isFinite(num)) { return null; }
+  if (!Number.isSafeInteger(num)) { return null; }
+  return Math.min(max, Math.max(1, num));
+};
+
 type PaginationProps = {
   pageSizeOptions?: Array<PageSizeOption>,
 };
 export const Pagination = ({ pageSizeOptions }: PaginationProps) => {
   const { table } = useTable();
-  const [pageIndexIndicator, setPageIndexIndicator] = React.useState<number>(1);
+  const [pageBuffer, setPageBuffer] = React.useState<string>('1');
+  const pageNumber = parsePageNumber(pageBuffer, table.pageCount) ?? (table.state.pageIndex + 1);
+  
   /*
   Available pagination state:
   - table.state.pageIndex
@@ -37,17 +46,19 @@ export const Pagination = ({ pageSizeOptions }: PaginationProps) => {
   - table.setPageSize
   */
   
+  // Sync the table state with the buffer
+  React.useEffect(() => {
+    setPageBuffer(String(table.state.pageIndex + 1));
+  }, [table.state.pageIndex]);
+  
   const updatePage = React.useCallback(() => {
-    const requestedIndex = Number.isSafeInteger(pageIndexIndicator) ? pageIndexIndicator - 1 : 0;
-    const targetIndex: number = Math.max(0, Math.min(table.pageCount - 1, requestedIndex));
-    
-    table.gotoPage(targetIndex);
-    setPageIndexIndicator(targetIndex + 1);
-  }, [pageIndexIndicator, table.pageCount, table.gotoPage]);
+    setPageBuffer(String(pageNumber));
+    table.gotoPage(pageNumber - 1);
+  }, [pageNumber, table.gotoPage]);
   
   return (
     <div className={cx(cl['bk-pagination'])}>
-      <PaginationSizeSelector pageSizeOptions={pageSizeOptions} setPageIndexIndicator={setPageIndexIndicator}/>
+      <PaginationSizeSelector pageSizeOptions={pageSizeOptions}/>
       
       <div className={cx(cl['pager'], cl['pager--indexed'])}>
         <IconButton
@@ -55,10 +66,7 @@ export const Pagination = ({ pageSizeOptions }: PaginationProps) => {
           icon="page-backward"
           label="Go to first page"
           nonactive={!table.canPreviousPage}
-          onPress={() => {
-            table.gotoPage(0)
-            setPageIndexIndicator(1);
-          }}
+          onPress={() => { table.gotoPage(0); }}
         />
         <div className={cx(cl['pagination-main'])}>
           <IconButton
@@ -66,10 +74,7 @@ export const Pagination = ({ pageSizeOptions }: PaginationProps) => {
             icon="caret-left"
             label="Go to previous page"
             nonactive={!table.canPreviousPage}
-            onPress={() => {
-              table.previousPage();
-              setPageIndexIndicator(pageIndexIndicator - 1);
-            }}
+            onPress={() => { table.previousPage(); }}
           />
           
           <span className="visually-hidden">Current page:</span>
@@ -79,10 +84,10 @@ export const Pagination = ({ pageSizeOptions }: PaginationProps) => {
             automaticResize
             className={cx(cl['pagination__page-input'])}
             inputProps={{ className: cx(cl['pagination__page-input__input']) }}
-            value={pageIndexIndicator}
-            max={table.pageCount}
-            onChange={(event) => { setPageIndexIndicator(Number.parseInt(event.target.value, 10)); }}
+            value={pageBuffer}
+            onChange={(event) => { setPageBuffer(event.target.value); }}
             onBlur={() => { updatePage(); }}
+            max={table.pageCount}
             onKeyDown={event => {
               if (event.key === 'Enter') {
                 updatePage();
@@ -95,10 +100,7 @@ export const Pagination = ({ pageSizeOptions }: PaginationProps) => {
             icon="caret-right"
             label="Go to next page"
             nonactive={!table.canNextPage}
-            onPress={() => {
-              table.nextPage();
-              setPageIndexIndicator(pageIndexIndicator + 1);
-            }}
+            onPress={() => { table.nextPage(); }}
           />
         </div>
         <IconButton
@@ -106,10 +108,7 @@ export const Pagination = ({ pageSizeOptions }: PaginationProps) => {
           icon="page-forward"
           nonactive={!table.canNextPage}
           label="Go to last page"
-          onPress={() => {
-            table.gotoPage(table.pageCount - 1)
-            setPageIndexIndicator(table.pageCount);
-          }}
+          onPress={() => { table.gotoPage(table.pageCount - 1); }}
         />
       </div>
     </div>

--- a/src/components/tables/DataTable/pagination/PaginationSizeSelector.tsx
+++ b/src/components/tables/DataTable/pagination/PaginationSizeSelector.tsx
@@ -19,6 +19,7 @@ export const defaultPageSizeOptions: Array<PageSizeOption> = [10, 25, 50, 100];
 type PaginationSizeSelectorProps = {
   pageSizeOptions?: undefined | Array<PageSizeOption>,
   pageSizeLabel?: undefined | string,
+  setPageIndexIndicator?: undefined | React.Dispatch<React.SetStateAction<number>>,
 };
 export const PaginationSizeSelector = (props: PaginationSizeSelectorProps) => {
   const { pageSizeOptions = defaultPageSizeOptions, pageSizeLabel = 'Rows per page' } = props;
@@ -39,6 +40,15 @@ export const PaginationSizeSelector = (props: PaginationSizeSelectorProps) => {
             label={`${pageSize}`}
             onSelect={() => {
               table.setPageSize(pageSize);
+              if (props.setPageIndexIndicator) {
+                // manually update the page index
+                const oldPageSize = table.state.pageSize;
+                const newPageSize = pageSize;
+                const oldPageIndex = table.state.pageIndex;
+                const newPageIndex = Math.floor(oldPageIndex * oldPageSize / newPageSize);
+                // page displayed is always +1 than the index
+                props.setPageIndexIndicator(newPageIndex + 1);
+              }
             }}
           />
         ))}

--- a/src/components/tables/DataTable/pagination/PaginationSizeSelector.tsx
+++ b/src/components/tables/DataTable/pagination/PaginationSizeSelector.tsx
@@ -19,7 +19,6 @@ export const defaultPageSizeOptions: Array<PageSizeOption> = [10, 25, 50, 100];
 type PaginationSizeSelectorProps = {
   pageSizeOptions?: undefined | Array<PageSizeOption>,
   pageSizeLabel?: undefined | string,
-  setPageIndexIndicator?: undefined | React.Dispatch<React.SetStateAction<number>>,
 };
 export const PaginationSizeSelector = (props: PaginationSizeSelectorProps) => {
   const { pageSizeOptions = defaultPageSizeOptions, pageSizeLabel = 'Rows per page' } = props;
@@ -35,21 +34,10 @@ export const PaginationSizeSelector = (props: PaginationSizeSelectorProps) => {
         className={cx(cl['page-size-selector__dropdown'])}
         items={pageSizeOptions.map((pageSize) => (
           <MenuProvider.Option
-            key={pageSize.toString()}
-            itemKey={pageSize.toString()}
-            label={`${pageSize}`}
-            onSelect={() => {
-              table.setPageSize(pageSize);
-              if (props.setPageIndexIndicator) {
-                // manually update the page index
-                const oldPageSize = table.state.pageSize;
-                const newPageSize = pageSize;
-                const oldPageIndex = table.state.pageIndex;
-                const newPageIndex = Math.floor(oldPageIndex * oldPageSize / newPageSize);
-                // page displayed is always +1 than the index
-                props.setPageIndexIndicator(newPageIndex + 1);
-              }
-            }}
+            key={pageSize}
+            itemKey={String(pageSize)}
+            label={String(pageSize)}
+            onSelect={() => { table.setPageSize(pageSize); }}
           />
         ))}
       >


### PR DESCRIPTION
Fixes #545

Steps to reproduce:
1. Open multiple pages large example, change page to 50
<img width="509" height="215" alt="image" src="https://github.com/user-attachments/assets/8ac3ee4e-5ad0-4fc9-abd4-1c399d822db1" />

2. Switch rows per page to another value, for instance 100, page gets updated:
<img width="509" height="215" alt="image" src="https://github.com/user-attachments/assets/9a1a8edf-74d6-498a-83b7-8b14a5005869" />
