### PR TITLE
`vite-plugin-dts` by default does not fail the build when there are errors, fix this through `afterDiagnostic`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - run: npm ci
-      #- run: npm run build --if-present
+      #- run: npm run build # Note: already runs as part of `npm ci` through the `prepare` hook
       - run: npm test
       - run: cd tests/installation && npm ci && npm test

--- a/src/components/util/collections/CollectionStore.tsx
+++ b/src/components/util/collections/CollectionStore.tsx
@@ -95,11 +95,14 @@ export const useCollectionWith = (store: StoreApi<CollectionSlice>, { onItemsCha
   };
 };
 
-type UseCollectionItemParams = { itemKey: ItemKey };
+type UseCollectionItemWithParams = { itemKey: ItemKey };
+type UseCollectionItemWithResult<E extends Element> = {
+  props: { ref: React.RefCallback<E>, 'data-bk-coll-parent': string, 'data-bk-coll-item': string },
+};
 export const useCollectionItemWith = <E extends Element>(
   store: StoreApi<CollectionSlice>,
-  { itemKey }: UseCollectionItemParams,
-) => {
+  { itemKey }: UseCollectionItemWithParams,
+): UseCollectionItemWithResult<E> => {
   const collectionId = useStore(store, state => state.collectionId);
   const registerItem = useStore(store, state => state.registerItem);
   const unregisterItem = useStore(store, state => state.unregisterItem);
@@ -169,7 +172,9 @@ type UseCollectionItemResult<E extends Element> = {
     'data-bk-coll-item': string,
   },
 };
-export const useCollectionItem = <E extends Element>(params: UseCollectionItemParams): UseCollectionItemResult<E> => {
+export const useCollectionItem = <E extends Element>(
+  params: UseCollectionItemWithParams,
+): UseCollectionItemResult<E> => {
   const { itemKey } = params;
   
   const { store } = useCollectionContext();

--- a/src/components/util/collections/RadioGroupStore.tsx
+++ b/src/components/util/collections/RadioGroupStore.tsx
@@ -87,7 +87,13 @@ export const useRadioGroup = (props: RadioGroupProps) => {
 
 
 type UseRadioGroupItemParams = { itemKey: ItemKey };
-export const useRadioGroupItem = <E extends Element>(params: UseRadioGroupItemParams) => {
+type UseRadioGroupItemResult<E extends Element> = {
+  store: StoreApi<RadioGroupSlice>,
+  selected: boolean,
+  requestSelected: () => void,
+  props: ReturnType<typeof useCollectionItemWith<E>>['props'],
+};
+export const useRadioGroupItem = <E extends Element>(params: UseRadioGroupItemParams): UseRadioGroupItemResult<E> => {
   const { itemKey } = params;
   
   const { store, requestSelected } = useRadioGroupContext();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,17 +48,16 @@ export default defineConfig({
       customDomId: 'baklava-icon-sprite',
     }),
     //libInjectCss(), // Disabled for now (`.css` import causes issues in vitest)
-
+    
     // Generate `.d.ts` files
     dts({
-      logLevel: 'error',
       // https://github.com/qmhc/vite-plugin-dts/issues/275#issuecomment-1963123685
       outDir: 'dist', // dts.root + 'dist' => where we need to rollup.
       root: '../', //vite.root + ../ = ./ = (dts.root)
       staticImport: true,
       insertTypesEntry: true,
       //rollupTypes: true, // Issue: https://github.com/qmhc/vite-plugin-dts/issues/399
-
+      
       //include: [path.resolve(__dirname, 'app')],
       tsconfigPath: path.resolve(__dirname, 'tsconfig.app.json'),
       

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
 
     // Generate `.d.ts` files
     dts({
+      logLevel: 'error',
       // https://github.com/qmhc/vite-plugin-dts/issues/275#issuecomment-1963123685
       outDir: 'dist', // dts.root + 'dist' => where we need to rollup.
       root: '../', //vite.root + ../ = ./ = (dts.root)
@@ -60,6 +61,15 @@ export default defineConfig({
 
       //include: [path.resolve(__dirname, 'app')],
       tsconfigPath: path.resolve(__dirname, 'tsconfig.app.json'),
+      
+      // `vite-plugin-dts` by default does not fail the build when there are errors
+      afterDiagnostic(diagnostics) {
+        // Categories: Warning = 0, Error = 1, Suggestion = 2, Message = 3
+        const errorDiagnostics = diagnostics.map(({ category }) => category === 0 || category === 1 );
+        if (errorDiagnostics.length > 0) {
+          throw new Error(`vite-plugin-dts reported ${errorDiagnostics.length} type error(s), failing the build.`)
+        }
+      },
     }),
   ],
   css: {


### PR DESCRIPTION
In release `v1.0.0-beta-20260706`, some TypeScript declaration files are missing. There were errors during the `build` command, but this managed to slip past CI since `vite-plugin-dts` didn't fail the build command automatically. This PR:

- Fixes the errors.
- Adds an `afterDiagnostic` to fail the build upon finding any errors.